### PR TITLE
42 coworkers page component

### DIFF
--- a/app/co-workers.tsx
+++ b/app/co-workers.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
-import { Image, StyleSheet, Platform, View, Text, Button } from 'react-native';
-
+import { StyleSheet } from 'react-native';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import CoworkersList from "@/components/CoworkersList";
 
 export default function CoWorkersPage() {
   return (
-      <ThemedView style={[styles.stepContainer, styles.container]}>
-        <ThemedText type="title">Coworkers</ThemedText>
+      <ThemedView style={[styles.container]}>
+        <ThemedText
+            style={styles.title}
+            type="title"
+        >
+          Coworkers
+        </ThemedText>
         <CoworkersList />
       </ThemedView>
   );
@@ -20,11 +24,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'flex-start',
   },
-
-  stepContainer: {
-    gap: 8,
-    marginBottom: 8,
-    paddingHorizontal: 16,
-    paddingTop: 16,
+  title: {
+    marginVertical: 8,
   },
 });

--- a/app/co-workers.tsx
+++ b/app/co-workers.tsx
@@ -1,35 +1,24 @@
 import React from 'react';
 import { Image, StyleSheet, Platform, View, Text, Button } from 'react-native';
 
-import ParallaxScrollView from '@/components/ParallaxScrollView';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
+import CoworkersList from "@/components/CoworkersList";
 
 export default function CoWorkersPage() {
   return (
-    <ParallaxScrollView
-      headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
-      headerImage={
-        <Image
-          source={require('@/assets/images/partial-react-logo.png')}
-          style={styles.reactLogo}
-        />
-      }>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Co-workers Page Placeholder</ThemedText>
-        <Text style={styles.message}>
-          This is a placeholder for the Co-workers page.
-        </Text>
+      <ThemedView style={[styles.stepContainer, styles.container]}>
+        <ThemedText type="title">Coworkers</ThemedText>
+        <CoworkersList />
       </ThemedView>
-    </ParallaxScrollView>
   );
 }
 
 const styles = StyleSheet.create({
-  titleContainer: {
-    flexDirection: 'row',
+  container: {
+    flex: 1,
     alignItems: 'center',
-    gap: 8,
+    justifyContent: 'flex-start',
   },
 
   stepContainer: {
@@ -38,20 +27,4 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 16,
   },
-
-  reactLogo: {
-    height: 178,
-    width: 290,
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
-  },
-
-  message: {
-    fontSize: 24,
-    marginBottom: 20,
-    color: '#333',
-    textAlign: 'center',
-  },
-  
 });

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -25,7 +25,10 @@ export default function HomeScreen(): ReactElement {
   // fetchMessage()
 
   const colorScheme = useColorScheme(); // Get the current color scheme (light/dark)
-
+    const linkStyle = [
+        styles.link,
+        { color: colorScheme === 'dark' ? '#ddd' : '#007bff' } // Dark mode: light color, light mode: blue
+    ];
   return (
     <ParallaxScrollView
       headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
@@ -41,18 +44,18 @@ export default function HomeScreen(): ReactElement {
         <HelloWave />
          <Link
           href="/forgot-password"
-          style={[
-            styles.link,
-            { color: colorScheme === 'dark' ? '#ddd' : '#007bff' } // Dark mode: light color, light mode: blue
-          ]}
+          style={linkStyle}
         >
           Forgot Password Page
         </Link>
         
         <Link     
-        style={[styles.link, { color: colorScheme === 'dark' ? '#ddd' : '#007bff' }]}
+        style={linkStyle}
         href="/help">Help Page</Link>
 
+        <Link
+            style={linkStyle}
+            href="/co-workers">Coworkers page</Link>
       
       </ThemedView>
 

--- a/components/CoworkerListItem.tsx
+++ b/components/CoworkerListItem.tsx
@@ -1,0 +1,63 @@
+import React, {FC} from "react";
+import {StyleSheet, View} from "react-native";
+import {ThemedView} from "@/components/ThemedView";
+import {ThemedText} from "@/components/ThemedText";
+import {Image} from "expo-image";
+import Ionicons from "@expo/vector-icons/Ionicons";
+
+export interface CoworkerProps {
+    id: string,
+    name: string,
+    role?: string | undefined
+    profileImageUrl?: string | undefined
+}
+const defaultProfilePicUrl = 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
+const handleChatButtonPressed = (name: string) => {
+    console.log(`Chat with ${name}`)
+}
+export const CoworkerListItem: FC<CoworkerProps> = ({ name, role, profileImageUrl }) => (
+    <ThemedView style={styles.container}>
+        <View style={styles.coworkerContainer}>
+            <Image
+                style={styles.profileImage}
+                source={profileImageUrl || defaultProfilePicUrl}
+            />
+            <View style={styles.basicInfoContainer}>
+                <ThemedText type={'subtitle'}>
+                    {name}
+                </ThemedText>
+                <ThemedText type={'role'}>
+                    {role}
+                </ThemedText>
+            </View>
+        </View>
+        <ThemedText>
+            <Ionicons
+                name={'chatbox-outline'}
+                size={24}
+                onPress={() => handleChatButtonPressed(name)}
+            />
+        </ThemedText>
+    </ThemedView>
+);
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        flexDirection: "row",
+        justifyContent: "space-between",
+        paddingHorizontal: 10
+    },
+    basicInfoContainer: {
+        marginLeft: 10
+    },
+    coworkerContainer: {
+        flex: 1,
+        flexDirection: "row",
+    },
+    profileImage: {
+        flex: 1,
+        maxWidth: 50,
+        borderRadius: 50
+    },
+});

--- a/components/CoworkerListItem.tsx
+++ b/components/CoworkerListItem.tsx
@@ -27,7 +27,7 @@ export const CoworkerListItem: FC<CoworkerProps> = ({ name, role, profileImageUr
                     {name}
                 </ThemedText>
                 <ThemedText type={'role'}>
-                    {role}
+                    {role || "User"}
                 </ThemedText>
             </View>
         </View>

--- a/components/CoworkerListItem.tsx
+++ b/components/CoworkerListItem.tsx
@@ -46,7 +46,7 @@ const styles = StyleSheet.create({
         flex: 1,
         flexDirection: "row",
         justifyContent: "space-between",
-        paddingHorizontal: 10
+        paddingHorizontal: 30
     },
     basicInfoContainer: {
         marginLeft: 10

--- a/components/CoworkersList.tsx
+++ b/components/CoworkersList.tsx
@@ -1,4 +1,4 @@
-import {FlatList, ListRenderItem, SafeAreaView, StyleSheet, View} from "react-native";
+import {FlatList, ListRenderItem, StyleSheet, View} from "react-native";
 import {coworkersDummyData} from "@/data/dummyCoworkerData";
 import {CoworkerListItem, CoworkerProps} from "@/components/CoworkerListItem";
 import React from "react";

--- a/components/CoworkersList.tsx
+++ b/components/CoworkersList.tsx
@@ -1,0 +1,39 @@
+import {FlatList, ListRenderItem, SafeAreaView, StyleSheet, View} from "react-native";
+import {coworkersDummyData} from "@/data/dummyCoworkerData";
+import {CoworkerListItem, CoworkerProps} from "@/components/CoworkerListItem";
+import React from "react";
+
+export default function CoworkersList() {
+    const renderCoworker: ListRenderItem<CoworkerProps> = ({ item }) =>
+        <CoworkerListItem
+            id={item.id}
+            name={item.name}
+            role={item.role}
+            profileImageUrl={item.profileImageUrl}
+
+        />;
+    interface ItemSeparatorProps {
+        height?: number;  // Optional prop to control the spacing height
+    }
+
+    const ItemSeparator: React.FC<ItemSeparatorProps> = ({ height = 10 }) => {
+        return <View style={{ height }} />;
+    };
+    return (
+        <View style={styles.coworkersList} >
+            <FlatList
+                data={coworkersDummyData}
+                renderItem={renderCoworker}
+                ItemSeparatorComponent={() => <ItemSeparator height={30}/>}
+            />
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+    coworkersList: {
+        flex: 1,
+        width: '100%',
+        paddingBottom: 20
+    }
+});

--- a/components/CoworkersList.tsx
+++ b/components/CoworkersList.tsx
@@ -25,6 +25,7 @@ export default function CoworkersList() {
                 data={coworkersDummyData}
                 renderItem={renderCoworker}
                 ItemSeparatorComponent={() => <ItemSeparator height={30}/>}
+                contentContainerStyle={{paddingBottom: 80}}
             />
         </View>
     )
@@ -34,6 +35,5 @@ const styles = StyleSheet.create({
     coworkersList: {
         flex: 1,
         width: '100%',
-        paddingBottom: 20
     }
 });

--- a/components/CoworkersList.tsx
+++ b/components/CoworkersList.tsx
@@ -26,6 +26,8 @@ export default function CoworkersList() {
                 renderItem={renderCoworker}
                 ItemSeparatorComponent={() => <ItemSeparator height={30}/>}
                 contentContainerStyle={{paddingBottom: 80}}
+                maxToRenderPerBatch={3}
+                windowSize={2}
             />
         </View>
     )

--- a/components/CoworkersList.tsx
+++ b/components/CoworkersList.tsx
@@ -10,7 +10,6 @@ export default function CoworkersList() {
             name={item.name}
             role={item.role}
             profileImageUrl={item.profileImageUrl}
-
         />;
     interface ItemSeparatorProps {
         height?: number;  // Optional prop to control the spacing height

--- a/components/ThemedText.tsx
+++ b/components/ThemedText.tsx
@@ -5,7 +5,7 @@ import { useThemeColor } from '@/hooks/useThemeColor';
 export type ThemedTextProps = TextProps & {
   lightColor?: string;
   darkColor?: string;
-  type?: 'default' | 'title' | 'defaultSemiBold' | 'subtitle' | 'link';
+  type?: 'default' | 'title' | 'defaultSemiBold' | 'subtitle' | 'link' | 'role';
 };
 
 export function ThemedText({
@@ -26,6 +26,7 @@ export function ThemedText({
         type === 'defaultSemiBold' ? styles.defaultSemiBold : undefined,
         type === 'subtitle' ? styles.subtitle : undefined,
         type === 'link' ? styles.link : undefined,
+        type == 'role' ? styles.role: undefined,
         style,
       ]}
       {...rest}
@@ -57,4 +58,9 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: '#0a7ea4',
   },
+  role: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: '#6b6868'
+  }
 });

--- a/data/dummyCoworkerData.ts
+++ b/data/dummyCoworkerData.ts
@@ -1,0 +1,172 @@
+export const coworkersDummyData = [
+    {
+        id: 'bd7acbea-c1b1-46c2-aed5-3ad53abb28ba',
+        name: 'Coworker 1',
+        role: 'Administrator',
+        profileImageUrl: 'https://images.ctfassets.net/h6goo9gw1hh6/2sNZtFAWOdP1lmQ33VwRN3/24e953b920a9cd0ff2e1d587742a2472/1-intro-photo-final.jpg'
+    },
+    {
+        id: '3ac68afc-c605-48d3-a4f8-fbd91aa97f63',
+        name: 'Coworker 2',
+        role: 'Teacher',
+        profileImageUrl: 'https://writestylesonline.com/wp-content/uploads/2018/11/Three-Statistics-That-Will-Make-You-Rethink-Your-Professional-Profile-Picture.jpg'
+    },
+    {
+        id: '58694a0f-3da1-471f-bd96-145571e29d72',
+        name: 'Coworker 3',
+        role: 'Dean',
+    },
+    {
+        id: 'bd7acaea-c1b1-46c2-aed5-3ad53abb28ba',
+        name: 'Coworker 1',
+        role: 'Administrator',
+        profileImageUrl: 'https://images.ctfassets.net/h6goo9gw1hh6/2sNZtFAWOdP1lmQ33VwRN3/24e953b920a9cd0ff2e1d587742a2472/1-intro-photo-final.jpg'
+    },
+    {
+        id: '3ac68fafc-c605-48d3-a4f8-fbd91aa97f63',
+        name: 'Coworker 2',
+        role: 'Teacher',
+        profileImageUrl: 'https://writestylesonline.com/wp-content/uploads/2018/11/Three-Statistics-That-Will-Make-You-Rethink-Your-Professional-Profile-Picture.jpg'
+    },
+    {
+        id: '58694a0ef-3da1-471f-bd96-145571e29d72',
+        name: 'Coworker 3',
+        role: 'Dean',
+    },
+    {
+        id: 'bd7acb3ea-c1b1-46c2-aed5-3ad53abb28ba',
+        name: 'Coworker 1',
+        role: 'Administrator',
+        profileImageUrl: 'https://images.ctfassets.net/h6goo9gw1hh6/2sNZtFAWOdP1lmQ33VwRN3/24e953b920a9cd0ff2e1d587742a2472/1-intro-photo-final.jpg'
+    },
+    {
+        id: '3ac68afc5-c605-48d3-a4f8-fbd91aa97f63',
+        name: 'Coworker 2',
+        role: 'Teacher',
+        profileImageUrl: 'https://writestylesonline.com/wp-content/uploads/2018/11/Three-Statistics-That-Will-Make-You-Rethink-Your-Professional-Profile-Picture.jpg'
+    },
+    {
+        id: '58694a06f-3da1-471f-bd96-145571e29d72',
+        name: 'Coworker 3',
+        role: 'Dean',
+    },
+    {
+        id: 'bd7acbea-c1b1-46c2-aed5-3ad853abb28ba',
+        name: 'Coworker 1',
+        role: 'Administrator',
+        profileImageUrl: 'https://images.ctfassets.net/h6goo9gw1hh6/2sNZtFAWOdP1lmQ33VwRN3/24e953b920a9cd0ff2e1d587742a2472/1-intro-photo-final.jpg'
+    },
+    {
+        id: '3ac68a8fc-c605-48d3-a4f8-fbd91aa97f63',
+        name: 'Coworker 2',
+        role: 'Teacher',
+        profileImageUrl: 'https://writestylesonline.com/wp-content/uploads/2018/11/Three-Statistics-That-Will-Make-You-Rethink-Your-Professional-Profile-Picture.jpg'
+    },
+    {
+        id: '58694a0f-3da1-4718f-bd96-145571e29d72',
+        name: 'Coworker 3',
+        role: 'Dean',
+    },
+    {
+        id: 'bd7acbea-c1b1-46c2-aed5-3ad53abb2-8ba',
+        name: 'Coworker 1',
+        role: 'Administrator',
+        profileImageUrl: 'https://images.ctfassets.net/h6goo9gw1hh6/2sNZtFAWOdP1lmQ33VwRN3/24e953b920a9cd0ff2e1d587742a2472/1-intro-photo-final.jpg'
+    },
+    {
+        id: '3ac68afc-c605y-48d3-a4f8-fbd91aa97f63',
+        name: 'Coworker 2',
+        role: 'Teacher',
+        profileImageUrl: 'https://writestylesonline.com/wp-content/uploads/2018/11/Three-Statistics-That-Will-Make-You-Rethink-Your-Professional-Profile-Picture.jpg'
+    },
+    {
+        id: '58694a0hf-3da1-471f-bd96-145571e29d72',
+        name: 'Coworker 3',
+        role: 'Dean',
+    },
+    {
+        id: 'bd7acgbea-c1b1-46c2-aed5-3ad53abb28ba',
+        name: 'Coworker 1',
+        role: 'Administrator',
+        profileImageUrl: 'https://images.ctfassets.net/h6goo9gw1hh6/2sNZtFAWOdP1lmQ33VwRN3/24e953b920a9cd0ff2e1d587742a2472/1-intro-photo-final.jpg'
+    },
+    {
+        id: '3ac68afc-c605-48d3-a4f8-fbd91a5a97f63',
+        name: 'Coworker 2',
+        role: 'Teacher',
+        profileImageUrl: 'https://writestylesonline.com/wp-content/uploads/2018/11/Three-Statistics-That-Will-Make-You-Rethink-Your-Professional-Profile-Picture.jpg'
+    },
+    {
+        id: '58694a0f-3da41-471f-bd96-145571e29d72',
+        name: 'Coworker 3',
+        role: 'Dean',
+    },
+    {
+        id: 'bd7acaea3-c1b1-46c2-aed5-3ad53abb28ba',
+        name: 'Coworker 1',
+        role: 'Administrator',
+        profileImageUrl: 'https://images.ctfassets.net/h6goo9gw1hh6/2sNZtFAWOdP1lmQ33VwRN3/24e953b920a9cd0ff2e1d587742a2472/1-intro-photo-final.jpg'
+    },
+    {
+        id: '3ac68fafc-c605-4a8d3-a4f8-fbd91aa97f63',
+        name: 'Coworker 2',
+        role: 'Teacher',
+        profileImageUrl: 'https://writestylesonline.com/wp-content/uploads/2018/11/Three-Statistics-That-Will-Make-You-Rethink-Your-Professional-Profile-Picture.jpg'
+    },
+    {
+        id: '58694a0ef-3da1-471f-bd96-145571e29hd72',
+        name: 'Coworker 3',
+        role: 'Dean',
+    },
+    {
+        id: 'bd7acb3eda-c1b1-46c2-aed5-3ad53abb28ba',
+        name: 'Coworker 1',
+        role: 'Administrator',
+        profileImageUrl: 'https://images.ctfassets.net/h6goo9gw1hh6/2sNZtFAWOdP1lmQ33VwRN3/24e953b920a9cd0ff2e1d587742a2472/1-intro-photo-final.jpg'
+    },
+    {
+        id: '3ac68afc5-c605-48d3d-a4f8-fbd91aa97f63',
+        name: 'Coworker 2',
+        role: 'Teacher',
+        profileImageUrl: 'https://writestylesonline.com/wp-content/uploads/2018/11/Three-Statistics-That-Will-Make-You-Rethink-Your-Professional-Profile-Picture.jpg'
+    },
+    {
+        id: '58694a06f-3da1-471f-bdf96-145571e29d72',
+        name: 'Coworker 3',
+        role: 'Dean',
+    },
+    {
+        id: 'bd7acbea-c1b1-46c2-aed54-3ad853abb28ba',
+        name: 'Coworker 1',
+        role: 'Administrator',
+        profileImageUrl: 'https://images.ctfassets.net/h6goo9gw1hh6/2sNZtFAWOdP1lmQ33VwRN3/24e953b920a9cd0ff2e1d587742a2472/1-intro-photo-final.jpg'
+    },
+    {
+        id: '3ac68a8fc-c605-48d3-a4f8-6fbd91aa97f63',
+        name: 'Coworker 2',
+        role: 'Teacher',
+        profileImageUrl: 'https://writestylesonline.com/wp-content/uploads/2018/11/Three-Statistics-That-Will-Make-You-Rethink-Your-Professional-Profile-Picture.jpg'
+    },
+    {
+        id: '58694a0f-3da1-4718f-bd926-145571e29d72',
+        name: 'Coworker 3',
+        role: 'Dean',
+    },
+    {
+        id: 'bd7acbea-c1b1-46c2-4aed5-3ad53abb2-8ba',
+        name: 'Coworker 1',
+        role: 'Administrator',
+        profileImageUrl: 'https://images.ctfassets.net/h6goo9gw1hh6/2sNZtFAWOdP1lmQ33VwRN3/24e953b920a9cd0ff2e1d587742a2472/1-intro-photo-final.jpg'
+    },
+    {
+        id: '3ac68afc-c605y6-48d3-a4f8-fbd91aa97f63',
+        name: 'Coworker 2',
+        role: 'Teacher',
+        profileImageUrl: 'https://writestylesonline.com/wp-content/uploads/2018/11/Three-Statistics-That-Will-Make-You-Rethink-Your-Professional-Profile-Picture.jpg'
+    },
+    {
+        id: '58u694a0hf-3da1-471f-bd96-145571e29d72',
+        name: 'Coworker 3',
+        role: 'Dean',
+    },
+];


### PR DESCRIPTION
This PR adds the coworkers component and displays it on the co-workers page.

### **Files added:**

### CoworkerListItem.tsx
This is the individual coworker item component. It consists of a profile picture, name text, role text and chat icon. When the chat icon is tapped a message with the name of the corresponding coworker is logged to the console. I also included a "default profile picture" that displays if the profile picture is null or undefined. Both the profileImageUrl and role props are nullable.

### CoworkersList.tsx
The Coworkers List defines a FlatList that displays a list of CoworkerListItems. I also made a simple ItemSeperator that basically acts as margin between the items. This could be updated and customized to be anything but right now it is just basically margin. This is the safer way to introduce margin between list items as applying vertical margins directly to the list item can cause uneven margins at the start and end of the container or even push list items off screen. The FlatList will also load items as the user scrolls, improving performance. For more information for how the FlatList is implemented check out the documentation here: [FlatList - React Native](https://reactnative.dev/docs/flatlist)

### dummyCoworkerData.ts
The dummyCoworkerData scrips contains a single array of dummy coworker objects. Each object has an id, name and role key. Some objects are missing the profileImageUrl key to demonstrate its behavior as a nullable prop.

### **Files changed:**
### co-workers.tsx
Added the CoworkersList component to the co-workers page and altered styles.

### index.tsx
added a link to the co-workers page. Created a variable for linkStyle that can be applied to all links. This will reduce code repetition.

### **Demo**:

https://github.com/user-attachments/assets/7bc70e3c-af63-44a8-ae7d-4223ec21ddaa

One thing to note was I was having weird issues on Android with the last coworker getting cut off of the screen and it wasn't until I added `contentContainerStyle={{paddingBottom: 80}}` to the FlatList that I was able to keep the last coworker from getting cut off the screen. You'll notice however in the video the gap at the bottom is larger the first time the bottom of the list is reached compared to the second time I scroll through the list.

First time reaching the bottom of the list:
![image](https://github.com/user-attachments/assets/75695db1-ff49-4902-bf50-ba899dd7b579)

Any other time reaching the bottom of the list:
![image](https://github.com/user-attachments/assets/da300e88-4582-44d7-beb6-587156f51991)

Its a minor bug but its something to be aware of. If anyone has any suggestions or insight in regards to this (or anything else) I would love to hear it!