### PR TITLE
shift-app-expo-sprint17_ Issue#75_connect-forgot-password-with-Login-page

### DIFF
--- a/app/forgot-password.tsx
+++ b/app/forgot-password.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
 import { Image, StyleSheet, TextInput, Button, Text } from 'react-native';
+import { Link } from 'expo-router';
 
 import ParallaxScrollView from '@/components/ParallaxScrollView';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { useColorScheme } from 'react-native';
+
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState('');
@@ -63,9 +65,9 @@ export default function ForgotPasswordPage() {
             disabled={isSubmitting}
           />
         {message !== '' && <Text style={styles.feedback}>{message}</Text>}
-          <Text style={styles.link} onPress={() => console.log('Navigate to Login')}>
-            Back to Login
-          </Text>
+        <Link href="/loginpage" style={styles.link}>
+        Back to Login
+        </Link> 
       </ThemedView>
     </ParallaxScrollView>
   );


### PR DESCRIPTION
this pull request  will add:

Link component from `expo-router` to navigate back to the login page. This change allows users to easily return to the login screen after initiating a password reset request.

These changes enhance the user experience by providing a clear and easy way to navigate back to the login page, improving the overall usability of the password reset functionality.


https://github.com/user-attachments/assets/df8a2ac6-bf62-4db7-8c4e-aeb9c8b55102

