### PR TITLE
Shift-Expo-App_17_68_remove_empty_link_component

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -50,8 +50,6 @@ export default function HomeScreen(): ReactElement {
             style={linkStyle}>Forgot Password Page</Link>
         <Link
             style={linkStyle}
-        <Link
-            style={linkStyle}
             href="/landing">Landing page</Link>
         <Link
             style={linkStyle}


### PR DESCRIPTION
Resolves <issue #72>

While I was resolving the conflicting file issue in GitHub in order to merge the PR after it has been reviewed and approved by at least two people, I left off a Link component during the merge (see screenshot).

<img width="622" alt="Screenshot 2025-02-11 181555" src="https://github.com/user-attachments/assets/0d01a62e-d7ee-434d-bfaa-fb0453583d68" />


The Link component has now been removed (see screen shot).

![Screenshot 2025-02-11 180640](https://github.com/user-attachments/assets/86c814ad-792f-42f3-bea8-0826e8ed3faf)


The feature I was originally working on (adding a link to the Landing page on the index.tsx, and once clicked, the route for the Login button on the landing.tsx will connect to the Login page) still works (see video walkthrough).

https://github.com/user-attachments/assets/8f0e2938-cdea-46c5-a3be-cd926c2bf34d