### PR TITLE
Shift_Expo_App-18-88-login-page-links-forgot-password-signup

### DIFF
--- a/app/(auth)/loginpage.tsx
+++ b/app/(auth)/loginpage.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'expo-router';
 import React, { useState } from 'react';
 import {
   View,
@@ -14,10 +15,19 @@ const { width } = Dimensions.get('window'); // Get the current screen width
 export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const router = useRouter();
 
   const handleLogin = () => {
     Alert.alert('Login', `Email: ${email}\nPassword: ${password}`);
   };
+
+  const goToForgotPassword = () => {
+    router.push('/(auth)/forgot-password');
+  }
+
+  const goToSignupPage = () => {
+    router.push('/(auth)/signuppage');
+  }
 
   return (
     <View style={styles.container}>
@@ -56,14 +66,14 @@ export default function LoginPage() {
       </TouchableOpacity>
 
       {/* Forgot Password Link */}
-      <TouchableOpacity>
+      <TouchableOpacity onPress={goToForgotPassword}>
         <Text style={styles.link}>Forgot Password?</Text>
       </TouchableOpacity>
 
       {/* Sign-Up Section */}
       <View style={styles.signUpContainer}>
         <Text style={styles.text}>Don't have an account? </Text>
-        <TouchableOpacity>
+        <TouchableOpacity onPress={goToSignupPage}>
           <Text style={styles.link}>Sign Up</Text>
         </TouchableOpacity>
       </View>


### PR DESCRIPTION
Resolves <issue #88>

This PR adds links for the Forgot Password page and Signup page to the Login page on the main screen.

Website walkthrough from Login page to Forgot Password and Signup pages:

https://github.com/user-attachments/assets/1f36f96a-357b-4d3e-a812-81163659a6a1


Emulator walkthrough from Login page to Forgot Password:

https://github.com/user-attachments/assets/5e96e574-501d-40af-b609-49d20bfeb690


Emulator walkthrough from Login page to Signup:

https://github.com/user-attachments/assets/2a95838b-8b6a-4ff9-8574-3a33c22559b9

