### PR TITLE
shift-app-expo_17_82_Fix text color with dark mode on Landing Page

### DIFF
--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -85,6 +85,7 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: 'bold',
     textAlign: 'center',
+    color: '#000',
   },
   buttonContainer: {
     backgroundColor: '#000',


### PR DESCRIPTION
Resolves <issue #82>

The text "Shift Scheduling App" was barely visible on the web version. This PR fixes that bug. The issue was that the default color, which was a faint grey, was being passed in, so I explicitly provided the color.

Before:
<img width="244" alt="411157696-26312b88-78d0-45d0-9ffa-8924dc68cffb" src="https://github.com/user-attachments/assets/a73ffca8-d47e-47b6-8dc2-e32c45472955" />

After:
https://github.com/user-attachments/assets/de6a5e69-96c4-45b3-a4f1-bfe4efb7f092
