### PR TITLE
104 edit profile page

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -57,6 +57,12 @@ export default function TabLayout() {
                     href: null
                 }}
             />
+            <Tabs.Screen
+                name="editProfile"
+                options={{
+                    href: null
+                }}
+            />
         </Tabs>
     );
 }

--- a/app/(tabs)/editProfile.tsx
+++ b/app/(tabs)/editProfile.tsx
@@ -1,0 +1,40 @@
+import {ScrollView, StyleSheet, View} from "react-native";
+import {ThemedText} from "@/components/ThemedText";
+import {ThemedView} from "@/components/ThemedView";
+
+export default function EditProfile () {
+    
+    return (
+        <ScrollView>
+            <View style={styles.headerContainer}>
+                <ThemedText type={'title'}>Edit Profile</ThemedText>
+                <ThemedView darkColor={'#fff'} lightColor={'#000'} style={styles.circle} >
+                    <ThemedText style={styles.userText} lightColor={'#fff'} darkColor={'#000'} >Tdfsfd</ThemedText>
+                </ThemedView>
+                <ThemedText style={{fontSize:24}} type={'default'}>
+                    Role: Ad Tutor
+                </ThemedText>
+            </View>
+        </ScrollView>
+    )
+}
+const circleSize = 125;
+const styles = StyleSheet.create({
+    headerContainer: {
+        flex:1,
+        alignItems:'center',
+        backgroundColor: 'yellow',
+        gap:15,
+        paddingVertical: 16
+    },
+    circle: {
+        borderRadius: circleSize / 2,
+        height: circleSize,
+        width: circleSize,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    userText: {
+        fontSize: 20
+    }
+})

--- a/app/(tabs)/editProfile.tsx
+++ b/app/(tabs)/editProfile.tsx
@@ -13,40 +13,43 @@ interface TextFieldWithLabelProps {
 }
 interface DropDownWithLabelProps {
     label: string,
-    values: string[]
+    values: string[],
+    selectedValue: string;
+    onValueChange: (itemValue: string) => void;
+}
+const TextFieldWithLabel = ({label, onChangeText, value, ...props}: TextFieldWithLabelProps) => {
+    return (
+        <View>
+            <Text style={styles.label}>{label}</Text>
+            <TextInput
+                {...props}
+                style={styles.input}
+                onChangeText={onChangeText}
+                value={value}
+            />
+        </View>
+    )
+}
+const DropdownWithLabel = ({label, values, selectedValue, onValueChange}: DropDownWithLabelProps) => {
+    return (
+        <View>
+            <Text style={styles.label}>{label}</Text>
+            <View style={styles.picker}>
+                <Picker selectedValue={selectedValue} onValueChange={onValueChange}>
+                    { values.map(v=> <Picker.Item key={v} label={v} value={v} />) }
+                </Picker>
+            </View>
+        </View>
+    )
 }
 export default function EditProfile () {
     const {firstName, lastName, email, pronouns} = useLocalSearchParams();
-    const [firstNameText, setFirstNameText] = useState(firstName);
-    const [lastNameText, setLastNameText] = useState(lastName);
-    const [emailText, setEmailText] = useState(email);
-    const [pronounsText, setPronounsText] = useState(pronouns);
+    const [firstNameText, setFirstNameText] = useState(firstName as string);
+    const [lastNameText, setLastNameText] = useState(lastName as string);
+    const [emailText, setEmailText] = useState(email as string);
+    const [pronounsText, setPronounsText] = useState(pronouns as string);
+    const [studentStatus, setStudentStatus] = useState('Full-Time');
     const router = useRouter();
-    const TextFieldWithLabel = ({label, onChangeText, value, ...props}: TextFieldWithLabelProps) => {
-        return (
-            <View>
-                <Text style={styles.label}>{label}</Text>
-                <TextInput
-                    {...props}
-                    style={styles.input}
-                    onChangeText={onChangeText}
-                    value={value}
-                />
-            </View>
-        )
-    }
-    const DropdownWithLabel = ({label, values}: DropDownWithLabelProps) => {
-        return (
-            <View>
-                <Text style={styles.label}>{label}</Text>
-                <View style={styles.picker}>
-                    <Picker>
-                        { values.map(v=> <Picker.Item key={v} label={v} value={v} />) }
-                    </Picker>
-                </View>
-            </View>
-        )
-    }
     const colorScheme = useColorScheme() || 'light';
     const studentStatuses = ['Full-Time', 'Part-Time']
     return (
@@ -66,24 +69,29 @@ export default function EditProfile () {
                 <TextFieldWithLabel
                     label={'First Name'}
                     onChangeText={setFirstNameText}
-                    value={firstNameText as string}
+                    value={firstNameText}
                 />
                 <TextFieldWithLabel
                     label={'Last Name'}
                     onChangeText={setLastNameText}
-                    value={lastNameText as string}
+                    value={lastNameText}
                 />
                 <TextFieldWithLabel
                     label={'Email'}
                     onChangeText={setEmailText}
-                    value={emailText as string}
+                    value={emailText}
                 />
                 <TextFieldWithLabel
                     label={'Pronouns'}
                     onChangeText={setPronounsText}
-                    value={pronounsText as string}
+                    value={pronounsText}
                 />
-                <DropdownWithLabel label={'Student Status'} values={studentStatuses} />
+                <DropdownWithLabel
+                    label={'Student Status'}
+                    values={studentStatuses}
+                    selectedValue={studentStatus}
+                    onValueChange={setStudentStatus}
+                />
                 <View style={styles.buttonsContainer}>
                     <Pressable onPress={() => console.log('submit')} style={[styles.button, {backgroundColor: Colors[colorScheme].text,}]}>
                         <Text style={{color: colorScheme == 'light' ? Colors.dark.text: Colors.light.text}}>

--- a/app/(tabs)/editProfile.tsx
+++ b/app/(tabs)/editProfile.tsx
@@ -52,7 +52,7 @@ export default function EditProfile () {
     const [studentStatus, setStudentStatus] = useState('Full-Time');
     const router = useRouter();
     const colorScheme = useColorScheme();
-    const studentStatuses = ['Full-Time', 'Part-Time']
+    const studentStatuses = ['Full-Time', 'Part-Time', 'Intern', 'Work-Study', "Leave Of Absence"]
     return (
         <ScrollView style={{backgroundColor: Colors[colorScheme || 'light'].background}}>
             <View style={styles.headerContainer}>

--- a/app/(tabs)/editProfile.tsx
+++ b/app/(tabs)/editProfile.tsx
@@ -1,4 +1,4 @@
-import {ScrollView, StyleSheet, TextInput, View, Text, Pressable, useColorScheme, Platform} from "react-native";
+import {ScrollView, StyleSheet, View, Text, Pressable, useColorScheme, Platform} from "react-native";
 import {ThemedText} from "@/components/ThemedText";
 import {ThemedView} from "@/components/ThemedView";
 import {useLocalSearchParams, useRouter} from "expo-router";

--- a/app/(tabs)/editProfile.tsx
+++ b/app/(tabs)/editProfile.tsx
@@ -43,7 +43,7 @@ const DropdownWithLabel = ({label, values, selectedValue, onValueChange}: DropDo
     )
 }
 export default function EditProfile () {
-    const {firstName, lastName, email, pronouns} = useLocalSearchParams();
+    const {firstName, lastName, email, pronouns, role} = useLocalSearchParams();
     const [firstNameText, setFirstNameText] = useState(firstName as string);
     const [lastNameText, setLastNameText] = useState(lastName as string);
     const [emailText, setEmailText] = useState(email as string);
@@ -62,7 +62,7 @@ export default function EditProfile () {
                     </ThemedText>
                 </ThemedView>
                 <ThemedText style={{fontSize:24}} type={'default'}>
-                    Role: Ad Tutor
+                    {`Role: ${role}`}
                 </ThemedText>
             </View>
             <View style={styles.editFieldsContainer}>

--- a/app/(tabs)/editProfile.tsx
+++ b/app/(tabs)/editProfile.tsx
@@ -20,7 +20,7 @@ interface DropDownWithLabelProps {
 const TextFieldWithLabel = ({label, onChangeText, value, ...props}: TextFieldWithLabelProps) => {
     return (
         <View>
-            <Text style={styles.label}>{label}</Text>
+            <ThemedText darkColor={'#ccc'} lightColor={'#333'} style={styles.label}>{label}</ThemedText>
             <TextInput
                 {...props}
                 style={styles.input}
@@ -33,7 +33,7 @@ const TextFieldWithLabel = ({label, onChangeText, value, ...props}: TextFieldWit
 const DropdownWithLabel = ({label, values, selectedValue, onValueChange}: DropDownWithLabelProps) => {
     return (
         <View>
-            <Text style={styles.label}>{label}</Text>
+            <ThemedText style={styles.label}>{label}</ThemedText>
             <View style={styles.picker}>
                 <Picker selectedValue={selectedValue} onValueChange={onValueChange}>
                     { values.map(v=> <Picker.Item key={v} label={v} value={v} />) }
@@ -43,7 +43,6 @@ const DropdownWithLabel = ({label, values, selectedValue, onValueChange}: DropDo
     )
 }
 const device = Platform.OS;
-let colorScheme;
 export default function EditProfile () {
     const {firstName, lastName, email, pronouns, role} = useLocalSearchParams();
     const [firstNameText, setFirstNameText] = useState(firstName as string);
@@ -52,7 +51,7 @@ export default function EditProfile () {
     const [pronounsText, setPronounsText] = useState(pronouns as string);
     const [studentStatus, setStudentStatus] = useState('Full-Time');
     const router = useRouter();
-    colorScheme = useColorScheme();
+    const colorScheme = useColorScheme();
     const studentStatuses = ['Full-Time', 'Part-Time']
     return (
         <ScrollView style={{backgroundColor: Colors[colorScheme || 'light'].background}}>
@@ -136,7 +135,6 @@ const styles = StyleSheet.create({
     label: {
         fontSize: 16,
         marginBottom: 5,
-        color: '#333',
     },
     input: {
         borderWidth: 1,

--- a/app/(tabs)/editProfile.tsx
+++ b/app/(tabs)/editProfile.tsx
@@ -1,4 +1,4 @@
-import {ScrollView, StyleSheet, TextInput, View, Text, Button, Pressable, useColorScheme} from "react-native";
+import {ScrollView, StyleSheet, TextInput, View, Text, Pressable, useColorScheme} from "react-native";
 import {ThemedText} from "@/components/ThemedText";
 import {ThemedView} from "@/components/ThemedView";
 import {Colors} from "@/constants/Colors";
@@ -33,7 +33,7 @@ export default function EditProfile () {
         )
     }
     const colorScheme = useColorScheme() || 'light';
-    const studentStatuses = ['Enrolled', 'Graduated', 'Dropped Out']
+    const studentStatuses = ['Full-Time', 'Part-Time']
     return (
         <ScrollView>
             <View style={styles.headerContainer}>

--- a/app/(tabs)/editProfile.tsx
+++ b/app/(tabs)/editProfile.tsx
@@ -26,7 +26,17 @@ export default function EditProfile () {
     const [studentStatus, setStudentStatus] = useState('Full-Time');
     const router = useRouter();
     const colorScheme = useColorScheme();
-    const studentStatuses = ['Full-Time', 'Part-Time', 'Intern', 'Work-Study', "Leave Of Absence"]
+    const studentStatuses = ['Full-Time', 'Part-Time', 'Intern', 'Work-Study', "Leave Of Absence"];
+
+    const handleCancelPressed = () => {
+        setFirstNameText(firstName);
+        setMiddleNameText(middleName);
+        setLastNameText(lastName);
+        setEmailText(email);
+        setPronounsText(pronouns);
+        // TODO: Handle student status
+        router.navigate('/(tabs)/profileView')
+    }
     return (
         <ScrollView style={{backgroundColor: Colors[colorScheme || 'light'].background}}>
             <View style={styles.headerContainer}>
@@ -85,7 +95,7 @@ export default function EditProfile () {
                             Submit
                         </Text>
                     </Pressable>
-                    <Pressable onPress={() => router.navigate('/(tabs)/profileView')} style={[styles.button, {backgroundColor: Colors.cancel,}]}>
+                    <Pressable onPress={handleCancelPressed} style={[styles.button, {backgroundColor: Colors.cancel,}]}>
                         <Text style={{color: colorScheme == 'light' ? Colors.dark.text: Colors.light.text}}>
                             Cancel
                         </Text>

--- a/app/(tabs)/editProfile.tsx
+++ b/app/(tabs)/editProfile.tsx
@@ -19,6 +19,7 @@ interface DropDownWithLabelProps {
 }
 type SearchParams = {
     firstName: string,
+    middleName: string,
     lastName: string,
     email: string,
     pronouns: string,
@@ -65,8 +66,9 @@ const DropdownWithLabel = ({label, values, selectedValue, onValueChange}: DropDo
 }
 const device = Platform.OS;
 export default function EditProfile () {
-    const {firstName, lastName, email, pronouns, role} = useLocalSearchParams<SearchParams>();
+    const {firstName, lastName, email, pronouns, role, middleName} = useLocalSearchParams<SearchParams>();
     const [firstNameText, setFirstNameText] = useState(firstName);
+    const [middleNameText, setMiddleNameText] = useState(middleName);
     const [lastNameText, setLastNameText] = useState(lastName);
     const [emailText, setEmailText] = useState(email);
     const [pronounsText, setPronounsText] = useState(pronouns);
@@ -99,6 +101,11 @@ export default function EditProfile () {
                     label={'First Name'}
                     onChangeText={setFirstNameText}
                     value={firstNameText}
+                />
+                <TextFieldWithLabel
+                    label={'Middle Name'}
+                    onChangeText={setMiddleNameText}
+                    value={middleName}
                 />
                 <TextFieldWithLabel
                     label={'Last Name'}

--- a/app/(tabs)/editProfile.tsx
+++ b/app/(tabs)/editProfile.tsx
@@ -1,19 +1,63 @@
-import {ScrollView, StyleSheet, View} from "react-native";
+import {ScrollView, StyleSheet, TextInput, View, Text, Button, Pressable, useColorScheme} from "react-native";
 import {ThemedText} from "@/components/ThemedText";
 import {ThemedView} from "@/components/ThemedView";
+import {Colors} from "@/constants/Colors";
+import {Picker} from "@react-native-picker/picker";
 
+interface TextFieldWithLabelProps {
+    label: string,
+}
+interface DropDownWithLabelProps {
+    label: string,
+    values: string[]
+}
 export default function EditProfile () {
-    
+    const TextFieldWithLabel = ({label, ...props}: TextFieldWithLabelProps) => {
+        return (
+            <View>
+                <Text style={styles.label}>{label}</Text>
+                <TextInput {...props} style={styles.input} />
+            </View>
+        )
+    }
+    const DropdownWithLabel = ({label, values}: DropDownWithLabelProps) => {
+        return (
+            <View>
+                <Text style={styles.label}>{label}</Text>
+                <View style={styles.picker}>
+                    <Picker>
+                        { values.map(v=> <Picker.Item key={v} label={v} value={v} />) }
+                    </Picker>
+                </View>
+            </View>
+        )
+    }
+    const colorScheme = useColorScheme() || 'light';
+    const studentStatuses = ['Enrolled', 'Graduated', 'Dropped Out']
     return (
         <ScrollView>
             <View style={styles.headerContainer}>
                 <ThemedText type={'title'}>Edit Profile</ThemedText>
                 <ThemedView darkColor={'#fff'} lightColor={'#000'} style={styles.circle} >
-                    <ThemedText style={styles.userText} lightColor={'#fff'} darkColor={'#000'} >Tdfsfd</ThemedText>
+                    <ThemedText style={styles.userText} lightColor={'#fff'} darkColor={'#000'} >
+                        T
+                    </ThemedText>
                 </ThemedView>
                 <ThemedText style={{fontSize:24}} type={'default'}>
                     Role: Ad Tutor
                 </ThemedText>
+            </View>
+            <View style={styles.editFieldsContainer}>
+                <TextFieldWithLabel label={'First Name'} />
+                <TextFieldWithLabel label={'Last Name'} />
+                <TextFieldWithLabel label={'Email'} />
+                <TextFieldWithLabel label={'Pronouns'} />
+                <DropdownWithLabel label={'Student Status'} values={studentStatuses} />
+                <Pressable onPress={() => console.log('submit')} style={[styles.button, {backgroundColor: Colors[colorScheme].text,}]}>
+                    <Text style={{color: colorScheme == 'light' ? Colors.dark.text: Colors.light.text}}>
+                        Submit
+                    </Text>
+                </Pressable>
             </View>
         </ScrollView>
     )
@@ -23,7 +67,7 @@ const styles = StyleSheet.create({
     headerContainer: {
         flex:1,
         alignItems:'center',
-        backgroundColor: 'yellow',
+        // backgroundColor: 'yellow',
         gap:15,
         paddingVertical: 16
     },
@@ -36,5 +80,32 @@ const styles = StyleSheet.create({
     },
     userText: {
         fontSize: 20
-    }
+    },
+    editFieldsContainer: {
+        flex: 1,
+        paddingHorizontal: 20,
+        gap: 10
+    },
+    label: {
+        fontSize: 16,
+        marginBottom: 5,
+        color: '#333',
+    },
+    input: {
+        borderWidth: 1,
+        borderColor: '#ccc',
+        borderRadius: 5,
+        padding: 10,
+        fontSize: 16,
+    },
+    button: {
+        padding: 12,
+        borderRadius: 5,
+        alignItems:'center'
+    },
+    picker: {
+        borderColor:'#ccc',
+        borderWidth: 1,
+        borderRadius: 5
+    },
 })

--- a/app/(tabs)/editProfile.tsx
+++ b/app/(tabs)/editProfile.tsx
@@ -3,20 +3,34 @@ import {ThemedText} from "@/components/ThemedText";
 import {ThemedView} from "@/components/ThemedView";
 import {Colors} from "@/constants/Colors";
 import {Picker} from "@react-native-picker/picker";
+import {useLocalSearchParams} from "expo-router";
+import {useState} from "react";
 
 interface TextFieldWithLabelProps {
     label: string,
+    onChangeText: (text: string) => void
+    value: string
 }
 interface DropDownWithLabelProps {
     label: string,
     values: string[]
 }
 export default function EditProfile () {
-    const TextFieldWithLabel = ({label, ...props}: TextFieldWithLabelProps) => {
+    const {firstName, lastName, email, pronouns} = useLocalSearchParams();
+    const [firstNameText, setFirstNameText] = useState(firstName);
+    const [lastNameText, setLastNameText] = useState(lastName);
+    const [emailText, setEmailText] = useState(email);
+    const [pronounsText, setPronounsText] = useState(pronouns);
+    const TextFieldWithLabel = ({label, onChangeText, value, ...props}: TextFieldWithLabelProps) => {
         return (
             <View>
                 <Text style={styles.label}>{label}</Text>
-                <TextInput {...props} style={styles.input} />
+                <TextInput
+                    {...props}
+                    style={styles.input}
+                    onChangeText={onChangeText}
+                    value={value}
+                />
             </View>
         )
     }
@@ -40,7 +54,7 @@ export default function EditProfile () {
                 <ThemedText type={'title'}>Edit Profile</ThemedText>
                 <ThemedView darkColor={'#fff'} lightColor={'#000'} style={styles.circle} >
                     <ThemedText style={styles.userText} lightColor={'#fff'} darkColor={'#000'} >
-                        T
+                        {`${firstName[0].toUpperCase()}${lastName[0].toUpperCase()}`}
                     </ThemedText>
                 </ThemedView>
                 <ThemedText style={{fontSize:24}} type={'default'}>
@@ -48,10 +62,26 @@ export default function EditProfile () {
                 </ThemedText>
             </View>
             <View style={styles.editFieldsContainer}>
-                <TextFieldWithLabel label={'First Name'} />
-                <TextFieldWithLabel label={'Last Name'} />
-                <TextFieldWithLabel label={'Email'} />
-                <TextFieldWithLabel label={'Pronouns'} />
+                <TextFieldWithLabel
+                    label={'First Name'}
+                    onChangeText={setFirstNameText}
+                    value={firstNameText as string}
+                />
+                <TextFieldWithLabel
+                    label={'Last Name'}
+                    onChangeText={setLastNameText}
+                    value={lastNameText as string}
+                />
+                <TextFieldWithLabel
+                    label={'Email'}
+                    onChangeText={setEmailText}
+                    value={emailText as string}
+                />
+                <TextFieldWithLabel
+                    label={'Pronouns'}
+                    onChangeText={setPronounsText}
+                    value={pronounsText as string}
+                />
                 <DropdownWithLabel label={'Student Status'} values={studentStatuses} />
                 <Pressable onPress={() => console.log('submit')} style={[styles.button, {backgroundColor: Colors[colorScheme].text,}]}>
                     <Text style={{color: colorScheme == 'light' ? Colors.dark.text: Colors.light.text}}>

--- a/app/(tabs)/editProfile.tsx
+++ b/app/(tabs)/editProfile.tsx
@@ -1,22 +1,11 @@
 import {ScrollView, StyleSheet, TextInput, View, Text, Pressable, useColorScheme, Platform} from "react-native";
 import {ThemedText} from "@/components/ThemedText";
 import {ThemedView} from "@/components/ThemedView";
-import {Colors} from "@/constants/Colors";
-import {Picker} from "@react-native-picker/picker";
 import {useLocalSearchParams, useRouter} from "expo-router";
 import {useState} from "react";
+import {DropdownWithLabel, TextFieldWithLabel} from "@/components/CustomInputFields";
+import {Colors} from "@/constants/Colors";
 
-interface TextFieldWithLabelProps {
-    label: string,
-    onChangeText: (text: string) => void
-    value: string
-}
-interface DropDownWithLabelProps {
-    label: string,
-    values: string[],
-    selectedValue: string;
-    onValueChange: (itemValue: string) => void;
-}
 type SearchParams = {
     firstName: string,
     middleName: string,
@@ -25,45 +14,7 @@ type SearchParams = {
     pronouns: string,
     role: string
 }
-const TextFieldWithLabel = ({label, onChangeText, value, ...props}: TextFieldWithLabelProps) => {
-    return (
-        <View>
-            <ThemedText
-                darkColor={Colors.dark.text}
-                lightColor={Colors.light.text}
-                style={styles.label}>
-                {label}
-            </ThemedText>
-            <TextInput
-                {...props}
-                style={styles.input}
-                onChangeText={onChangeText}
-                value={value}
-            />
-        </View>
-    )
-}
-const DropdownWithLabel = ({label, values, selectedValue, onValueChange}: DropDownWithLabelProps) => {
-    return (
-        <View>
-            <ThemedText
-                darkColor={Colors.dark.text}
-                lightColor={Colors.light.text}
-                style={styles.label}>
-                {label}
-            </ThemedText>
-            <ThemedView style={[styles.picker]}>
-                <Picker
-                    style={{color:Colors.light.text, backgroundColor:Colors.light.background}}
-                    selectedValue={selectedValue}
-                    onValueChange={onValueChange}
-                >
-                    { values.map(v=> <Picker.Item key={v} label={v} value={v} />) }
-                </Picker>
-            </ThemedView>
-        </View>
-    )
-}
+
 const device = Platform.OS;
 export default function EditProfile () {
     const {firstName, lastName, email, pronouns, role, middleName} = useLocalSearchParams<SearchParams>();
@@ -167,18 +118,6 @@ const styles = StyleSheet.create({
         paddingHorizontal: 20,
         gap: 10
     },
-    label: {
-        fontSize: 16,
-        marginBottom: 5,
-    },
-    input: {
-        borderWidth: 1,
-        borderColor: '#ccc',
-        borderRadius: 5,
-        padding: 10,
-        fontSize: 16,
-        backgroundColor:'#fff'
-    },
     button: {
         flex: 1,
         padding: 12,
@@ -186,11 +125,6 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         justifyContent: 'center',
         height: device == 'web' ? 36 : 'auto'
-    },
-    picker: {
-        borderColor:'#ccc',
-        borderWidth: 1,
-        borderRadius: 5
     },
     buttonsContainer: {
         flex:1,

--- a/app/(tabs)/editProfile.tsx
+++ b/app/(tabs)/editProfile.tsx
@@ -105,7 +105,7 @@ export default function EditProfile () {
                 <TextFieldWithLabel
                     label={'Middle Name'}
                     onChangeText={setMiddleNameText}
-                    value={middleName}
+                    value={middleNameText}
                 />
                 <TextFieldWithLabel
                     label={'Last Name'}

--- a/app/(tabs)/editProfile.tsx
+++ b/app/(tabs)/editProfile.tsx
@@ -20,7 +20,12 @@ interface DropDownWithLabelProps {
 const TextFieldWithLabel = ({label, onChangeText, value, ...props}: TextFieldWithLabelProps) => {
     return (
         <View>
-            <ThemedText darkColor={'#ccc'} lightColor={'#333'} style={styles.label}>{label}</ThemedText>
+            <ThemedText
+                darkColor={'#ccc'}
+                lightColor={'#333'}
+                style={styles.label}>
+                {label}
+            </ThemedText>
             <TextInput
                 {...props}
                 style={styles.input}
@@ -33,12 +38,21 @@ const TextFieldWithLabel = ({label, onChangeText, value, ...props}: TextFieldWit
 const DropdownWithLabel = ({label, values, selectedValue, onValueChange}: DropDownWithLabelProps) => {
     return (
         <View>
-            <ThemedText style={styles.label}>{label}</ThemedText>
-            <View style={styles.picker}>
-                <Picker selectedValue={selectedValue} onValueChange={onValueChange}>
+            <ThemedText
+                darkColor={'#ccc'}
+                lightColor={'#333'}
+                style={styles.label}>
+                {label}
+            </ThemedText>
+            <ThemedView style={[styles.picker]}>
+                <Picker
+                    style={{color:Colors.light.text, backgroundColor:Colors.light.background}}
+                    selectedValue={selectedValue}
+                    onValueChange={onValueChange}
+                >
                     { values.map(v=> <Picker.Item key={v} label={v} value={v} />) }
                 </Picker>
-            </View>
+            </ThemedView>
         </View>
     )
 }

--- a/app/(tabs)/editProfile.tsx
+++ b/app/(tabs)/editProfile.tsx
@@ -1,4 +1,4 @@
-import {ScrollView, StyleSheet, TextInput, View, Text, Pressable, useColorScheme} from "react-native";
+import {ScrollView, StyleSheet, TextInput, View, Text, Pressable, useColorScheme, Platform} from "react-native";
 import {ThemedText} from "@/components/ThemedText";
 import {ThemedView} from "@/components/ThemedView";
 import {Colors} from "@/constants/Colors";
@@ -42,6 +42,8 @@ const DropdownWithLabel = ({label, values, selectedValue, onValueChange}: DropDo
         </View>
     )
 }
+const device = Platform.OS;
+let colorScheme;
 export default function EditProfile () {
     const {firstName, lastName, email, pronouns, role} = useLocalSearchParams();
     const [firstNameText, setFirstNameText] = useState(firstName as string);
@@ -50,10 +52,10 @@ export default function EditProfile () {
     const [pronounsText, setPronounsText] = useState(pronouns as string);
     const [studentStatus, setStudentStatus] = useState('Full-Time');
     const router = useRouter();
-    const colorScheme = useColorScheme() || 'light';
+    colorScheme = useColorScheme();
     const studentStatuses = ['Full-Time', 'Part-Time']
     return (
-        <ScrollView>
+        <ScrollView style={{backgroundColor: Colors[colorScheme || 'light'].background}}>
             <View style={styles.headerContainer}>
                 <ThemedText type={'title'}>Edit Profile</ThemedText>
                 <ThemedView darkColor={'#fff'} lightColor={'#000'} style={styles.circle} >
@@ -93,7 +95,7 @@ export default function EditProfile () {
                     onValueChange={setStudentStatus}
                 />
                 <View style={styles.buttonsContainer}>
-                    <Pressable onPress={() => console.log('submit')} style={[styles.button, {backgroundColor: Colors[colorScheme].text,}]}>
+                    <Pressable onPress={() => console.log('submit')} style={[styles.button, {backgroundColor: Colors[colorScheme || 'light'].text,}]}>
                         <Text style={{color: colorScheme == 'light' ? Colors.dark.text: Colors.light.text}}>
                             Submit
                         </Text>
@@ -113,7 +115,6 @@ const styles = StyleSheet.create({
     headerContainer: {
         flex:1,
         alignItems:'center',
-        // backgroundColor: 'yellow',
         gap:15,
         paddingVertical: 16
     },
@@ -143,12 +144,15 @@ const styles = StyleSheet.create({
         borderRadius: 5,
         padding: 10,
         fontSize: 16,
+        backgroundColor:'#fff'
     },
     button: {
         flex: 1,
         padding: 12,
         borderRadius: 5,
-        alignItems:'center'
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: device == 'web' ? 36 : 'auto'
     },
     picker: {
         borderColor:'#ccc',
@@ -160,6 +164,5 @@ const styles = StyleSheet.create({
         flexDirection:'row',
         justifyContent:'center',
         gap: 5,
-        width:'100%'
     }
 })

--- a/app/(tabs)/editProfile.tsx
+++ b/app/(tabs)/editProfile.tsx
@@ -28,8 +28,8 @@ const TextFieldWithLabel = ({label, onChangeText, value, ...props}: TextFieldWit
     return (
         <View>
             <ThemedText
-                darkColor={'#ccc'}
-                lightColor={'#333'}
+                darkColor={Colors.dark.text}
+                lightColor={Colors.light.text}
                 style={styles.label}>
                 {label}
             </ThemedText>
@@ -46,8 +46,8 @@ const DropdownWithLabel = ({label, values, selectedValue, onValueChange}: DropDo
     return (
         <View>
             <ThemedText
-                darkColor={'#ccc'}
-                lightColor={'#333'}
+                darkColor={Colors.dark.text}
+                lightColor={Colors.light.text}
                 style={styles.label}>
                 {label}
             </ThemedText>
@@ -78,8 +78,15 @@ export default function EditProfile () {
         <ScrollView style={{backgroundColor: Colors[colorScheme || 'light'].background}}>
             <View style={styles.headerContainer}>
                 <ThemedText type={'title'}>Edit Profile</ThemedText>
-                <ThemedView darkColor={'#fff'} lightColor={'#000'} style={styles.circle} >
-                    <ThemedText style={styles.userText} lightColor={'#fff'} darkColor={'#000'} >
+                <ThemedView
+                    darkColor={Colors.light.background}
+                    lightColor={Colors.dark.background}
+                    style={styles.circle} >
+                    <ThemedText
+                        style={styles.userText}
+                        lightColor={Colors.light.background}
+                        darkColor={Colors.dark.background}
+                    >
                         {`${firstName[0].toUpperCase()}${lastName[0].toUpperCase()}`}
                     </ThemedText>
                 </ThemedView>

--- a/app/(tabs)/editProfile.tsx
+++ b/app/(tabs)/editProfile.tsx
@@ -17,6 +17,13 @@ interface DropDownWithLabelProps {
     selectedValue: string;
     onValueChange: (itemValue: string) => void;
 }
+type SearchParams = {
+    firstName: string,
+    lastName: string,
+    email: string,
+    pronouns: string,
+    role: string
+}
 const TextFieldWithLabel = ({label, onChangeText, value, ...props}: TextFieldWithLabelProps) => {
     return (
         <View>
@@ -58,11 +65,11 @@ const DropdownWithLabel = ({label, values, selectedValue, onValueChange}: DropDo
 }
 const device = Platform.OS;
 export default function EditProfile () {
-    const {firstName, lastName, email, pronouns, role} = useLocalSearchParams();
-    const [firstNameText, setFirstNameText] = useState(firstName as string);
-    const [lastNameText, setLastNameText] = useState(lastName as string);
-    const [emailText, setEmailText] = useState(email as string);
-    const [pronounsText, setPronounsText] = useState(pronouns as string);
+    const {firstName, lastName, email, pronouns, role} = useLocalSearchParams<SearchParams>();
+    const [firstNameText, setFirstNameText] = useState(firstName);
+    const [lastNameText, setLastNameText] = useState(lastName);
+    const [emailText, setEmailText] = useState(email);
+    const [pronounsText, setPronounsText] = useState(pronouns);
     const [studentStatus, setStudentStatus] = useState('Full-Time');
     const router = useRouter();
     const colorScheme = useColorScheme();

--- a/app/(tabs)/editProfile.tsx
+++ b/app/(tabs)/editProfile.tsx
@@ -3,7 +3,7 @@ import {ThemedText} from "@/components/ThemedText";
 import {ThemedView} from "@/components/ThemedView";
 import {Colors} from "@/constants/Colors";
 import {Picker} from "@react-native-picker/picker";
-import {useLocalSearchParams} from "expo-router";
+import {useLocalSearchParams, useRouter} from "expo-router";
 import {useState} from "react";
 
 interface TextFieldWithLabelProps {
@@ -21,6 +21,7 @@ export default function EditProfile () {
     const [lastNameText, setLastNameText] = useState(lastName);
     const [emailText, setEmailText] = useState(email);
     const [pronounsText, setPronounsText] = useState(pronouns);
+    const router = useRouter();
     const TextFieldWithLabel = ({label, onChangeText, value, ...props}: TextFieldWithLabelProps) => {
         return (
             <View>
@@ -83,11 +84,18 @@ export default function EditProfile () {
                     value={pronounsText as string}
                 />
                 <DropdownWithLabel label={'Student Status'} values={studentStatuses} />
-                <Pressable onPress={() => console.log('submit')} style={[styles.button, {backgroundColor: Colors[colorScheme].text,}]}>
-                    <Text style={{color: colorScheme == 'light' ? Colors.dark.text: Colors.light.text}}>
-                        Submit
-                    </Text>
-                </Pressable>
+                <View style={styles.buttonsContainer}>
+                    <Pressable onPress={() => console.log('submit')} style={[styles.button, {backgroundColor: Colors[colorScheme].text,}]}>
+                        <Text style={{color: colorScheme == 'light' ? Colors.dark.text: Colors.light.text}}>
+                            Submit
+                        </Text>
+                    </Pressable>
+                    <Pressable onPress={() => router.navigate('/(tabs)/profileView')} style={[styles.button, {backgroundColor: Colors.cancel,}]}>
+                        <Text style={{color: colorScheme == 'light' ? Colors.dark.text: Colors.light.text}}>
+                            Cancel
+                        </Text>
+                    </Pressable>
+                </View>
             </View>
         </ScrollView>
     )
@@ -129,6 +137,7 @@ const styles = StyleSheet.create({
         fontSize: 16,
     },
     button: {
+        flex: 1,
         padding: 12,
         borderRadius: 5,
         alignItems:'center'
@@ -138,4 +147,11 @@ const styles = StyleSheet.create({
         borderWidth: 1,
         borderRadius: 5
     },
+    buttonsContainer: {
+        flex:1,
+        flexDirection:'row',
+        justifyContent:'center',
+        gap: 5,
+        width:'100%'
+    }
 })

--- a/app/(tabs)/profileView.tsx
+++ b/app/(tabs)/profileView.tsx
@@ -4,6 +4,8 @@ import { ScrollView } from "react-native";
 import { Image } from "expo-image";
 import Feather from "@expo/vector-icons/Feather";
 import { UserDetails } from "@/components/UserDetails";
+import Ionicons from "@expo/vector-icons/Ionicons";
+import {Link} from "expo-router";
 
 
 const userName = "user_name";
@@ -11,7 +13,7 @@ const userName = "user_name";
 export default function AdminDashboard() {
   return (
     <>
-      <ScrollView>
+      <ScrollView contentContainerStyle={{justifyContent:'space-between'}}>
         <View style={styles.container}>
         <View style={styles.profile}>
           <Image
@@ -19,7 +21,10 @@ export default function AdminDashboard() {
             source="../assets/images/profileImg.jpg"
           />
         </View>
-        <UserDetails />
+          <Link style={{left: 100, top: 20, zIndex: 999}} href="/editProfile">
+            <Ionicons name={'pencil-outline'} size={20} />
+          </Link>
+            <UserDetails />
           <View><Text>Hi!, {userName}!</Text></View>
         </View>
         <View style={styles.border}>

--- a/app/(tabs)/profileView.tsx
+++ b/app/(tabs)/profileView.tsx
@@ -21,9 +21,6 @@ export default function AdminDashboard() {
             source="../assets/images/profileImg.jpg"
           />
         </View>
-          <Link style={{left: 100, top: 20, zIndex: 999}} href="/editProfile">
-            <Ionicons name={'pencil-outline'} size={20} />
-          </Link>
             <UserDetails />
           <View><Text>Hi!, {userName}!</Text></View>
         </View>

--- a/app/(tabs)/profileView.tsx
+++ b/app/(tabs)/profileView.tsx
@@ -4,9 +4,6 @@ import { ScrollView } from "react-native";
 import { Image } from "expo-image";
 import Feather from "@expo/vector-icons/Feather";
 import { UserDetails } from "@/components/UserDetails";
-import Ionicons from "@expo/vector-icons/Ionicons";
-import {Link} from "expo-router";
-
 
 const userName = "user_name";
 

--- a/components/CustomInputFields.tsx
+++ b/components/CustomInputFields.tsx
@@ -1,0 +1,81 @@
+import {TextInput, View, StyleSheet} from "react-native";
+import {ThemedText} from "@/components/ThemedText";
+import {Colors} from "@/constants/Colors";
+import {ThemedView} from "@/components/ThemedView";
+import {Picker} from "@react-native-picker/picker";
+
+interface TextFieldWithLabelProps {
+    label: string,
+    onChangeText: (text: string) => void
+    value: string
+}
+interface TextFieldWithLabelProps {
+    label: string,
+    onChangeText: (text: string) => void
+    value: string
+}
+interface DropDownWithLabelProps {
+    label: string,
+    values: string[],
+    selectedValue: string;
+    onValueChange: (itemValue: string) => void;
+}
+
+export const TextFieldWithLabel = ({label, onChangeText, value, ...props}: TextFieldWithLabelProps) => {
+    return (
+        <View>
+            <ThemedText
+                darkColor={Colors.dark.text}
+                lightColor={Colors.light.text}
+                style={styles.label}>
+                {label}
+            </ThemedText>
+            <TextInput
+                {...props}
+                style={styles.input}
+                onChangeText={onChangeText}
+                value={value}
+            />
+        </View>
+    )
+}
+export const DropdownWithLabel = ({label, values, selectedValue, onValueChange}: DropDownWithLabelProps) => {
+    return (
+        <View>
+            <ThemedText
+                darkColor={Colors.dark.text}
+                lightColor={Colors.light.text}
+                style={styles.label}>
+                {label}
+            </ThemedText>
+            <ThemedView style={[styles.picker]}>
+                <Picker
+                    style={{color:Colors.light.text, backgroundColor:Colors.light.background}}
+                    selectedValue={selectedValue}
+                    onValueChange={onValueChange}
+                >
+                    { values.map(v=> <Picker.Item key={v} label={v} value={v} />) }
+                </Picker>
+            </ThemedView>
+        </View>
+    )
+}
+const styles = StyleSheet.create({
+    label: {
+        fontSize: 16,
+        marginBottom: 5,
+    },
+    input: {
+        borderWidth: 1,
+        borderColor: '#ccc',
+        borderRadius: 5,
+        padding: 10,
+        fontSize: 16,
+        backgroundColor:'#fff'
+    },
+    picker: {
+        borderColor:'#ccc',
+        borderWidth: 1,
+        borderRadius: 5
+    },
+})

--- a/components/UserDetails.tsx
+++ b/components/UserDetails.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import { Text, View, StyleSheet } from "react-native";
+import {Link} from "expo-router";
+import Ionicons from "@expo/vector-icons/Ionicons";
 
 export const UserDetails = () => {
   const firstName = "first name";
@@ -9,10 +11,25 @@ export const UserDetails = () => {
   const supervisor = "supervisor";
   const email = "email";
   const phoneNumber = "(206) 999-9999";
+  const pronouns ='they/them'
   return (
     <>
         <View style={styles.container}>
             <View>
+                <Link
+                    style={{alignSelf:'flex-end'}}
+                    href={{
+                        pathname:"/editProfile",
+                        params: {
+                            firstName,
+                            lastName,
+                            email,
+                            pronouns
+                        }
+                    }}
+                >
+                    <Ionicons name={'pencil-outline'} size={20} />
+                </Link>
                 <View>
                     <Text style={styles.heading}>User Details</Text>
                     <Text style={styles.text}>First Name: {firstName}</Text>

--- a/components/UserDetails.tsx
+++ b/components/UserDetails.tsx
@@ -11,7 +11,8 @@ export const UserDetails = () => {
   const supervisor = "supervisor";
   const email = "email";
   const phoneNumber = "(206) 999-9999";
-  const pronouns ='they/them'
+  const pronouns ='they/them';
+  const role = 'student'
   return (
     <>
         <View style={styles.container}>
@@ -24,7 +25,8 @@ export const UserDetails = () => {
                             firstName,
                             lastName,
                             email,
-                            pronouns
+                            pronouns,
+                            role
                         }
                     }}
                 >

--- a/components/UserDetails.tsx
+++ b/components/UserDetails.tsx
@@ -5,6 +5,7 @@ import Ionicons from "@expo/vector-icons/Ionicons";
 
 export const UserDetails = () => {
   const firstName = "first name";
+  const middleName = "middle name";
   const lastName = "last name";
   const dateHired = "2222-22-22";
   const dept = "department";
@@ -23,6 +24,7 @@ export const UserDetails = () => {
                         pathname:"/editProfile",
                         params: {
                             firstName,
+                            middleName,
                             lastName,
                             email,
                             pronouns,
@@ -35,6 +37,7 @@ export const UserDetails = () => {
                 <View>
                     <Text style={styles.heading}>User Details</Text>
                     <Text style={styles.text}>First Name: {firstName}</Text>
+                    <Text style={styles.text}>Middle Name: {middleName}</Text>
                     <Text style={styles.text}>Last Name: {lastName}</Text>
                     <Text style={styles.text}>Date Hired: {dateHired}</Text>
                     <Text style={styles.text}>Department: {dept}</Text>

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -23,4 +23,5 @@ export const Colors = {
     tabIconDefault: '#9BA1A6',
     tabIconSelected: tintColorDark,
   },
+  cancel: '#d51414'
 };


### PR DESCRIPTION
resolves #104 

This PR implements the Edit Profile Page basic layout. The edit profile page displays user information at the top of the page including first & last initial and the role. Underneath that are several custom text input fields and one Dropdown picker field for the student status. These custom components provide a label & text field for inputting text in the text field and a `<Picker />` component from `react-native-picker`. Finally, at the bottom of the page is a submit button and cancel button. Currently the submit button does nothing but log a message to the console, while the cancel button navigates to the previous page. Note also that there is basically no field validation implemented yet. I figured that could be implemented in a separate issue.

### How to access:
Go to the main app features by tapping the top link on app startup "Go to main app features after login"
From there navigate to the profile page via tab navigator.
You'll notice a small pencil in the corner of the UserDetails container on the profile page. Tap that to navigate to the Edit profile page. The page should populate all of the text fields with the current user information to make for a better user experience.

### Android:

https://github.com/user-attachments/assets/b08e67f6-38ca-415a-af3b-22ce800cbbda

Dark mode:
![image](https://github.com/user-attachments/assets/00496688-d6bf-43cf-a8ef-f62b2d9c42c4)

Light mode:
![image](https://github.com/user-attachments/assets/9d9cb745-30c9-45bf-b0da-c07c8b143e87)

### Web:

https://github.com/user-attachments/assets/a8f9431b-64f1-45a2-9af2-8b3fc1fa978a

Dark mode:
![image](https://github.com/user-attachments/assets/9b380a5a-b9ef-4d51-b0e9-52c66b7a4e8f)

Light mode:
![image](https://github.com/user-attachments/assets/ddc5ce28-adbc-4dc4-b2c5-22cf1ff272ea)


