### PR TITLE
SHIFT-APP-EXPO-19-117-UPDATE_FORGOT_PASSWORD_PAGE

### DIFF
--- a/app/(auth)/forgot-password.tsx
+++ b/app/(auth)/forgot-password.tsx
@@ -1,4 +1,6 @@
-import React, { useState } from 'react';
+import * as React from 'react';
+
+
 import {
   View,
   Text,
@@ -9,19 +11,29 @@ import {
 } from 'react-native';
 import { Link } from 'expo-router';
 
-const { width } = Dimensions.get('window'); 
+const { width } = Dimensions.get('window');
+
+const isValidEmail = (email: string) => {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+};
+
 export default function ForgotPasswordPage() {
-  const [email, setEmail] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [message, setMessage] = useState('');
+  const [email, setEmail] = React.useState('');
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [message, setMessage] = React.useState('');
+  const [emailError, setEmailError] = React.useState('');
 
   const handlePasswordReset = () => {
-    if (!email.includes('@')) {
-      setMessage('Please enter a valid email address.');
+    if (!isValidEmail(email)) {
+      setEmailError('Invalid email address');
       return;
     }
+
+    setEmailError('');
     setIsSubmitting(true);
     setMessage('');
+
     setTimeout(() => {
       setIsSubmitting(false);
       setMessage('If this email is registered, you will receive a reset link.');
@@ -30,10 +42,8 @@ export default function ForgotPasswordPage() {
 
   return (
     <View style={styles.container}>
-      
       <Text style={styles.title}>Forgot Password</Text>
 
-      
       <View style={styles.inputContainer}>
         <Text style={styles.label}>Email</Text>
         <TextInput
@@ -41,13 +51,16 @@ export default function ForgotPasswordPage() {
           placeholder="Enter your email"
           placeholderTextColor="#888"
           value={email}
-          onChangeText={setEmail}
+          onChangeText={(text) => {
+            setEmail(text);
+            setEmailError('');
+          }}
           keyboardType="email-address"
           autoCapitalize="none"
         />
+        {emailError ? <Text style={styles.errorText}>{emailError}</Text> : null}
       </View>
 
-      
       <TouchableOpacity
         style={[styles.submitButton, isSubmitting && styles.disabledButton]}
         onPress={handlePasswordReset}
@@ -58,11 +71,11 @@ export default function ForgotPasswordPage() {
         </Text>
       </TouchableOpacity>
 
-      
       {message !== '' && <Text style={styles.feedback}>{message}</Text>}
 
-      
-      <Link href="/loginpage" style={styles.link}>Back to Login</Link>
+      <Link href="/loginpage" style={styles.link}>
+        <Text style={{ textDecorationLine: 'none', color: '#007BFF' }}>Back to Login</Text>
+      </Link>
     </View>
   );
 }
@@ -100,6 +113,11 @@ const styles = StyleSheet.create({
     fontSize: 16,
     backgroundColor: '#f9f9f9',
   },
+  errorText: {
+    color: 'red',
+    fontSize: 14,
+    marginTop: 5,
+  },
   submitButton: {
     width: '85%',
     maxWidth: 400,
@@ -125,9 +143,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   link: {
-    color: '#007BFF',
     fontSize: 14,
     marginTop: 5,
-    textDecorationLine: 'underline',
   },
 });


### PR DESCRIPTION

Goal
The goal of this task was to improve the Forgot Password Page by implementing the following changes:

Incorporate regex-based email validation to ensure only valid email addresses are submitted.
Display "Invalid email address" message beneath the input field if the email does not meet the required format.
Remove the underline from "Back to Login" to improve UI consistency.

How to Test the Fix

1- Run the following command in your terminal:

npx expo start

This will open Expo Developer Tools.

2- Test Email Validation

Open the Forgot Password Page.
Enter an invalid email (e.g., user123@ or user.com).
Expected: "Invalid email address" message should appear.

Enter a valid email (e.g., [test@example.com](mailto:test@example.com)).
Expected: Error message disappears.

Check the "Back to Login" Link
Click "Back to Login".
Expected: The app navigates back to the login page.
Expected: The text should NOT be underlined.

ps: I did not change the dependency I just installed - npm install

![Screenshot_9-3-2025_231344_localhost](https://github.com/user-attachments/assets/a3861df3-fb89-4619-bcc3-bfb818519af6)
