### PR TITLE
Shift_App_Exp_20_123_Detail-Page-Arrow_Navigation

### DIFF
--- a/app/(tabs)/shift-details-page/[id].tsx
+++ b/app/(tabs)/shift-details-page/[id].tsx
@@ -5,15 +5,23 @@ import {ThemedView} from "@/components/ThemedView";
 import {weekdays, months} from "moment";
 import Ionicons from "@expo/vector-icons/Ionicons";
 import {Colors} from '@/constants/Colors'
+import {useShiftNavigation} from "@/app/shift-navigation";
 
 export default function ShiftDetailsPage () {
     const item = useLocalSearchParams();
     const colorScheme = useColorScheme() || 'light';
-    const date = new Date(item.date as string) || new Date()
+
+    const currentShiftId = parseInt(item.id as string);
+
+    const { currentShift, goToPreviousShift, goToNextShift } = useShiftNavigation(currentShiftId);
+
+    const date = currentShift ? new Date(currentShift.date) : new Date();
+
     const day = date.getDate();
     const month = months()[date.getMonth()];
     const dayOfWeek = weekdays()[date.getDay()];
     const formattedDate = `${dayOfWeek}, ${month} ${day}`
+
     type PressableIconProps = {
         name: keyof typeof Ionicons.glyphMap;
         size?: number;
@@ -59,9 +67,9 @@ export default function ShiftDetailsPage () {
     return (
         <ThemedView style={styles.container}>
             <View style={styles.dateHeader}>
-                <PressableIcon name={'arrow-back'} onPress={() => console.log('prev')} />
+                <PressableIcon name={'arrow-back'} onPress={goToPreviousShift} />
                 <ThemedText type={'default'}>{formattedDate}</ThemedText>
-                <PressableIcon name={'arrow-forward'} onPress={() => console.log('next')} />
+                <PressableIcon name={'arrow-forward'} onPress={goToNextShift} />
             </View>
             <ThemedView style={styles.detailsContainer}>
                 <Text style={{alignSelf: 'center', fontWeight:'500', fontSize: 18}}>

--- a/app/shift-navigation.tsx
+++ b/app/shift-navigation.tsx
@@ -1,0 +1,73 @@
+import { useRouter } from "expo-router";
+import { Platform, Alert } from "react-native";
+import { shiftData, ShiftData } from "@/data/dummyShiftData";
+
+export const useShiftNavigation = (currentShiftId: number) => {
+  const router = useRouter();
+  
+  const currentShift = shiftData.find(shift => shift.id === currentShiftId);
+  
+  const allDates = [...new Set(shiftData.map(shift => shift.date))].sort();
+  
+  const currentDateIndex = allDates.indexOf(currentShift?.date || "");
+  
+  const findShiftOnDate = (date: string): ShiftData | undefined => {
+    return shiftData.find(shift => shift.date === date);
+  };
+  
+  const showAlert = (title: string, message: string): void => {
+    if (Platform.OS === 'web') {
+      window.alert(`${title}\n${message}`);
+    } else {
+      Alert.alert(title, message);
+    }
+  };
+  
+  const goToPreviousShift = () => {
+    if (currentDateIndex > 0) {
+      const prevDate = allDates[currentDateIndex - 1];
+      const prevShift = findShiftOnDate(prevDate);
+      
+      if (prevShift) {
+        router.setParams({
+          id: prevShift.id.toString(),
+          date: prevShift.date,
+          startTime: prevShift.startTime,
+          endTime: prevShift.endTime,
+          role: prevShift.role,
+          building: prevShift.building,
+          roomNumber: prevShift.roomNumber
+        });
+      }
+    } else {
+      showAlert("No previous shifts available", "You're reached the beginning of your scheduled shifts.");
+    }
+  };
+  
+  const goToNextShift = () => {
+    if (currentDateIndex < allDates.length - 1) {
+      const nextDate = allDates[currentDateIndex + 1];
+      const nextShift = findShiftOnDate(nextDate);
+      
+      if (nextShift) {
+        router.setParams({
+          id: nextShift.id.toString(),
+          date: nextShift.date,
+          startTime: nextShift.startTime,
+          endTime: nextShift.endTime,
+          role: nextShift.role,
+          building: nextShift.building,
+          roomNumber: nextShift.roomNumber
+        });
+      }
+    } else {
+      showAlert("No more shifts available", "You've reached the end of your scheduled shifts.");
+    }
+  };
+  
+  return {
+    currentShift,
+    goToPreviousShift,
+    goToNextShift
+  };
+};


### PR DESCRIPTION
<!-- Please fill out the following: -->
## Summary & Changes 📃
- **Resolves:** `#123`

- **Summary:** (Briefly describe what this PR does)
  - This issue fixes the previous and forward navigation arrow functionality on the Shift Detail page. Before, the arrows would not navigate to the previous or next shift.
  -  The expected behavior is to be able to click the previous arrow to navigate to the previous shift, while clicking the next arrow will allow you to navigate to the next shift. If you get to the first shift and click previous arrow, an alert will pop-up that you have reached the beginning of the shifts. The same will happen for the end of the shifts.

- **Changes:**
  - A new component was created (shift-navigation.tsx) to separate concerns for the navigation utilities and UI functions.

## Screenshots / Visual Aids 🔎
https://github.com/user-attachments/assets/76cf6286-7a02-4e56-b05d-4cc292f8192a

## Checklist ✅

- [X] I have **tested** this PR **locally** and it works as expected.
- [X] This PR **resolves an issue** (`Resolves #123 `).
- [X] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [ ] **Squash commits** and enable **auto-merge** if approved.

