### PR TITLE
Migrate Add-Shift.tsx to placeholder

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -12,9 +12,9 @@ export default function TabLayout() {
                 }}
             />
             <Tabs.Screen
-                name="addShift"
+                name="add-shift"
                 options={{
-                    title: 'Add shift',
+                    title: 'Add Shift',
                     tabBarIcon: ({ color }) => <FontAwesome size={28} name="calendar-plus-o" color={color} />,
                 }}
             />

--- a/app/(tabs)/add-shift.tsx
+++ b/app/(tabs)/add-shift.tsx
@@ -1,0 +1,3 @@
+import AddShift from '../../components/AddShift'
+
+export default AddShift;

--- a/app/(tabs)/addShift.tsx
+++ b/app/(tabs)/addShift.tsx
@@ -1,9 +1,0 @@
-import {View,Text} from "react-native";
-
-export default function AddShift() {
-    return (
-        <View>
-            <Text>Add shifts placeholder pager</Text>
-        </View>
-    )
-}

--- a/app/add-schedule.tsx
+++ b/app/add-schedule.tsx
@@ -1,3 +1,3 @@
-import AddSchedule from '../components/AddSchedule';
+import AddShift from '../components/AddShift';
 
-export default AddSchedule;
+export default AddShift;

--- a/components/AddShift.tsx
+++ b/components/AddShift.tsx
@@ -18,7 +18,7 @@ import { times } from "../data/times";
 
 type PickerType = "role" | "location" | "startTime" | "endTime" | null;
 
-const AddSchedule: React.FC = () => {
+const AddShift: React.FC = () => {
   const [role, setRole] = useState<string>(roles[0].value);
   const [location, setLocation] = useState<string>(locations[0].value);
   const [date, setDate] = useState<Date>(new Date());
@@ -56,7 +56,7 @@ const AddSchedule: React.FC = () => {
     <KeyboardAvoidingView behavior="padding" style={styles.container}>
       <ScrollView contentContainerStyle={styles.scrollContainer} keyboardShouldPersistTaps="handled">
         <View style={styles.innerContainer}>
-          <Text style={styles.title}>Add Schedule</Text>
+          <Text style={styles.title}>Add Shift</Text>
 
           {/* Role Picker */}
           <Text style={styles.label}>Role</Text>
@@ -167,4 +167,4 @@ const styles = StyleSheet.create({
   webInput: { fontSize: 16, padding: 12, borderWidth: 1, borderColor: "#ccc", borderRadius: 10, backgroundColor: "#fff", marginBottom: 20, width: "92%" },
 });
 
-export default AddSchedule;
+export default AddShift;


### PR DESCRIPTION
**Resolves:** #142 

**Summary:**
This is migrating the `add-shift.tsx page` (formerly known as the `add-schedule.tsx`) to the appropriate `(tabs)` folder within the app, allowing the "Add Shift" tab at the bottom to access the page to allow for adding a shift. 

**Changes:**
- Migrates `add-shift.tsx` to `shift-app-expo/app/(tabs) folder`
- Renames former `AddSchedule.tsx` component to `AddShift.tsx`, changing text references within the page, as well
- References corrected to allow for appropriate access to files and components

## Screenshots / Visual Aids 🔎
![Add Shift page and tab](https://github.com/user-attachments/assets/21b2d786-598e-40b6-8118-ef751f87ca84)

## How to Test 🧪
1. Check out this branch! Open the app by means of your IDE. No need for dedicated DB support on this one.
2. Go to the "Add Shift" tab at the bottom of the app and determine that the Add Shift page is loading correctly.