### PR TITLE
Adding update caret to react-navigation/native

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "dependencies": {
         "@expo/cli": "^0.22.26",
         "@expo/vector-icons": "^14.0.4",
-        "@react-native-async-storage/async-storage": "^1.23.1",
+        "@react-native-async-storage/async-storage": "1.23.1",
         "@react-native-community/datetimepicker": "8.2.0",
         "@react-native-picker/picker": "2.9.0",
         "@react-navigation/bottom-tabs": "7.2.0",
-        "@react-navigation/native": "7.0.15",
+        "@react-navigation/native": "^7.0.15",
         "@react-navigation/stack": "7.1.2",
         "@supabase/supabase-js": "^2.49.8",
         "expo": "^52.0.46",
@@ -3615,9 +3615,9 @@
       }
     },
     "node_modules/@react-native-async-storage/async-storage": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
-      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.23.1.tgz",
+      "integrity": "sha512-Qd2kQ3yi6Y3+AcUlrHxSLlnBvpdCEMVGFlVBneVOjaFaPU61g1huc38g339ysXspwY1QZA2aNhrk/KlHGO+ewA==",
       "license": "MIT",
       "dependencies": {
         "merge-options": "^3.0.4"
@@ -4063,28 +4063,6 @@
         "react-native-screens": ">= 4.0.0"
       }
     },
-    "node_modules/@react-navigation/bottom-tabs/node_modules/@react-navigation/elements": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.4.4.tgz",
-      "integrity": "sha512-6OAzrg6mn8s3qv6DZSFHxYRZv/3hUZTtkrq1XNBqLNlVIv89Iv7XKukYbZIxNoUss8r+RLJea0aNAOq5jbBkfw==",
-      "license": "MIT",
-      "dependencies": {
-        "color": "^4.2.3",
-        "use-latest-callback": "^0.2.4"
-      },
-      "peerDependencies": {
-        "@react-native-masked-view/masked-view": ">= 0.2.0",
-        "@react-navigation/native": "^7.1.11",
-        "react": ">= 18.2.0",
-        "react-native": "*",
-        "react-native-safe-area-context": ">= 4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@react-native-masked-view/masked-view": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@react-navigation/core": {
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.10.1.tgz",
@@ -4103,87 +4081,7 @@
         "react": ">= 18.2.0"
       }
     },
-    "node_modules/@react-navigation/core/node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/@react-navigation/native": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.0.15.tgz",
-      "integrity": "sha512-72PabJJ8VY3GM8i/DCutFW+ATED96ZV6NH+bW+ry1EL0ZFGHoie96H+KzTqktsrUbBw1rd9KXbEQhBQgo0N7iQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-navigation/core": "^7.4.0",
-        "escape-string-regexp": "^4.0.0",
-        "fast-deep-equal": "^3.1.3",
-        "nanoid": "3.3.8",
-        "use-latest-callback": "^0.2.1"
-      },
-      "peerDependencies": {
-        "react": ">= 18.2.0",
-        "react-native": "*"
-      }
-    },
-    "node_modules/@react-navigation/routers": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-7.4.1.tgz",
-      "integrity": "sha512-42mZrMzQ0LfKxUb5OHIurYrPYyRsXFLolucILrvm21f0O40Sw0Ufh1bnn/jRqnxZZu7wvpUGIGYM8nS9zVE1Aw==",
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11"
-      }
-    },
-    "node_modules/@react-navigation/routers/node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/@react-navigation/stack": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@react-navigation/stack/-/stack-7.1.2.tgz",
-      "integrity": "sha512-uRFec2SeZP7Urgekzake5AbWt1llsfxZdRqd9plOKnUTpSDhRO45d1XidgnB4eguJF4Yvdb8c2Ge3ZB3rvfCxg==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-navigation/elements": "^2.2.6",
-        "color": "^4.2.3"
-      },
-      "peerDependencies": {
-        "@react-navigation/native": "^7.0.15",
-        "react": ">= 18.2.0",
-        "react-native": "*",
-        "react-native-gesture-handler": ">= 2.0.0",
-        "react-native-safe-area-context": ">= 4.0.0",
-        "react-native-screens": ">= 4.0.0"
-      }
-    },
-    "node_modules/@react-navigation/stack/node_modules/@react-navigation/elements": {
+    "node_modules/@react-navigation/elements": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.4.4.tgz",
       "integrity": "sha512-6OAzrg6mn8s3qv6DZSFHxYRZv/3hUZTtkrq1XNBqLNlVIv89Iv7XKukYbZIxNoUss8r+RLJea0aNAOq5jbBkfw==",
@@ -4203,6 +4101,67 @@
         "@react-native-masked-view/masked-view": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-navigation/native": {
+      "version": "7.1.11",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.11.tgz",
+      "integrity": "sha512-f/UETxy2Nahr8jko9mSSRBvIaDubGc3M2yx5pWxMPxZgLkB4TqPB0O1OFdbcAuRDwLgzXXK+Joh7nTdGug9v2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/core": "^7.10.1",
+        "escape-string-regexp": "^4.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "nanoid": "^3.3.11",
+        "use-latest-callback": "^0.2.4"
+      },
+      "peerDependencies": {
+        "react": ">= 18.2.0",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@react-navigation/native-stack": {
+      "version": "7.3.16",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.3.16.tgz",
+      "integrity": "sha512-tK29buswgQtHE/8+HMeYfsio/t6Y0Yk+YlEBckaYvNbxOrCwQ/s2FrM4dyV3dHkSefT6eEae3NKSgD0Q2ARMAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.4.4",
+        "warn-once": "^0.1.1"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.1.11",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
+      }
+    },
+    "node_modules/@react-navigation/routers": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-7.4.1.tgz",
+      "integrity": "sha512-42mZrMzQ0LfKxUb5OHIurYrPYyRsXFLolucILrvm21f0O40Sw0Ufh1bnn/jRqnxZZu7wvpUGIGYM8nS9zVE1Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11"
+      }
+    },
+    "node_modules/@react-navigation/stack": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@react-navigation/stack/-/stack-7.1.2.tgz",
+      "integrity": "sha512-uRFec2SeZP7Urgekzake5AbWt1llsfxZdRqd9plOKnUTpSDhRO45d1XidgnB4eguJF4Yvdb8c2Ge3ZB3rvfCxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.2.6",
+        "color": "^4.2.3"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.0.15",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-gesture-handler": ">= 2.0.0",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
       }
     },
     "node_modules/@segment/loosely-validate-event": {
@@ -7379,80 +7338,6 @@
         "react-native-reanimated": {
           "optional": true
         }
-      }
-    },
-    "node_modules/expo-router/node_modules/@react-navigation/elements": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.4.4.tgz",
-      "integrity": "sha512-6OAzrg6mn8s3qv6DZSFHxYRZv/3hUZTtkrq1XNBqLNlVIv89Iv7XKukYbZIxNoUss8r+RLJea0aNAOq5jbBkfw==",
-      "license": "MIT",
-      "dependencies": {
-        "color": "^4.2.3",
-        "use-latest-callback": "^0.2.4"
-      },
-      "peerDependencies": {
-        "@react-native-masked-view/masked-view": ">= 0.2.0",
-        "@react-navigation/native": "^7.1.11",
-        "react": ">= 18.2.0",
-        "react-native": "*",
-        "react-native-safe-area-context": ">= 4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@react-native-masked-view/masked-view": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/expo-router/node_modules/@react-navigation/native": {
-      "version": "7.1.11",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.11.tgz",
-      "integrity": "sha512-f/UETxy2Nahr8jko9mSSRBvIaDubGc3M2yx5pWxMPxZgLkB4TqPB0O1OFdbcAuRDwLgzXXK+Joh7nTdGug9v2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-navigation/core": "^7.10.1",
-        "escape-string-regexp": "^4.0.0",
-        "fast-deep-equal": "^3.1.3",
-        "nanoid": "^3.3.11",
-        "use-latest-callback": "^0.2.4"
-      },
-      "peerDependencies": {
-        "react": ">= 18.2.0",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo-router/node_modules/@react-navigation/native-stack": {
-      "version": "7.3.16",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.3.16.tgz",
-      "integrity": "sha512-tK29buswgQtHE/8+HMeYfsio/t6Y0Yk+YlEBckaYvNbxOrCwQ/s2FrM4dyV3dHkSefT6eEae3NKSgD0Q2ARMAA==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-navigation/elements": "^2.4.4",
-        "warn-once": "^0.1.1"
-      },
-      "peerDependencies": {
-        "@react-navigation/native": "^7.1.11",
-        "react": ">= 18.2.0",
-        "react-native": "*",
-        "react-native-safe-area-context": ">= 4.0.0",
-        "react-native-screens": ">= 4.0.0"
-      }
-    },
-    "node_modules/expo-router/node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/expo-router/node_modules/semver": {
@@ -11251,9 +11136,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@react-native-community/datetimepicker": "8.2.0",
         "@react-native-picker/picker": "2.9.0",
         "@react-navigation/bottom-tabs": "7.2.0",
-        "@react-navigation/native": "^7.0.15",
+        "@react-navigation/native": "7.1.x",
         "@react-navigation/stack": "7.1.2",
         "@supabase/supabase-js": "^2.49.8",
         "expo": "^52.0.46",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@expo/cli": "^0.22.26",
         "@expo/vector-icons": "^14.0.4",
-        "@react-native-async-storage/async-storage": "1.23.1",
+        "@react-native-async-storage/async-storage": "^1.23.1",
         "@react-native-community/datetimepicker": "8.2.0",
         "@react-native-picker/picker": "2.9.0",
         "@react-navigation/bottom-tabs": "7.2.0",
@@ -3615,9 +3615,9 @@
       }
     },
     "node_modules/@react-native-async-storage/async-storage": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.23.1.tgz",
-      "integrity": "sha512-Qd2kQ3yi6Y3+AcUlrHxSLlnBvpdCEMVGFlVBneVOjaFaPU61g1huc38g339ysXspwY1QZA2aNhrk/KlHGO+ewA==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
       "license": "MIT",
       "dependencies": {
         "merge-options": "^3.0.4"
@@ -4064,16 +4064,17 @@
       }
     },
     "node_modules/@react-navigation/bottom-tabs/node_modules/@react-navigation/elements": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.4.3.tgz",
-      "integrity": "sha512-psoNmnZ0DQIt9nxxPITVLtYW04PGCAfnmd/Pcd3yhiBs93aj+HYKH+SDZDpUnXMf3BN7Wvo4+jPI+/Xjqb+m9w==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.4.4.tgz",
+      "integrity": "sha512-6OAzrg6mn8s3qv6DZSFHxYRZv/3hUZTtkrq1XNBqLNlVIv89Iv7XKukYbZIxNoUss8r+RLJea0aNAOq5jbBkfw==",
       "license": "MIT",
       "dependencies": {
-        "color": "^4.2.3"
+        "color": "^4.2.3",
+        "use-latest-callback": "^0.2.4"
       },
       "peerDependencies": {
         "@react-native-masked-view/masked-view": ">= 0.2.0",
-        "@react-navigation/native": "^7.1.10",
+        "@react-navigation/native": "^7.1.11",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0"
@@ -4085,17 +4086,17 @@
       }
     },
     "node_modules/@react-navigation/core": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.10.0.tgz",
-      "integrity": "sha512-qZBA5gGm+9liT4+EHk+kl9apwvqh7HqhLF1XeX6SQRmC/n2QI0u1B8OevKc+EPUDEM9Od15IuwT/GRbSs7/Umw==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.10.1.tgz",
+      "integrity": "sha512-6+bdalOqfDzc968s3Xz7VaUpPzMKzVay48dW+C/cd6sga01Iqjp4XAzQ7FNHdT7wgJYdvZaBOAlyvnok0OsFZw==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/routers": "^7.4.0",
+        "@react-navigation/routers": "^7.4.1",
         "escape-string-regexp": "^4.0.0",
         "nanoid": "^3.3.11",
         "query-string": "^7.1.3",
         "react-is": "^19.1.0",
-        "use-latest-callback": "^0.2.3",
+        "use-latest-callback": "^0.2.4",
         "use-sync-external-store": "^1.5.0"
       },
       "peerDependencies": {
@@ -4138,9 +4139,9 @@
       }
     },
     "node_modules/@react-navigation/routers": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-7.4.0.tgz",
-      "integrity": "sha512-th5THnuWKJlmr7GGHiicy979di11ycDWub9iIXbEDvQwmwmsRzppmVbfs2nD8bC/MgyMgqWu/gxfys+HqN+kcw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-7.4.1.tgz",
+      "integrity": "sha512-42mZrMzQ0LfKxUb5OHIurYrPYyRsXFLolucILrvm21f0O40Sw0Ufh1bnn/jRqnxZZu7wvpUGIGYM8nS9zVE1Aw==",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11"
@@ -4183,16 +4184,17 @@
       }
     },
     "node_modules/@react-navigation/stack/node_modules/@react-navigation/elements": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.4.3.tgz",
-      "integrity": "sha512-psoNmnZ0DQIt9nxxPITVLtYW04PGCAfnmd/Pcd3yhiBs93aj+HYKH+SDZDpUnXMf3BN7Wvo4+jPI+/Xjqb+m9w==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.4.4.tgz",
+      "integrity": "sha512-6OAzrg6mn8s3qv6DZSFHxYRZv/3hUZTtkrq1XNBqLNlVIv89Iv7XKukYbZIxNoUss8r+RLJea0aNAOq5jbBkfw==",
       "license": "MIT",
       "dependencies": {
-        "color": "^4.2.3"
+        "color": "^4.2.3",
+        "use-latest-callback": "^0.2.4"
       },
       "peerDependencies": {
         "@react-native-masked-view/masked-view": ">= 0.2.0",
-        "@react-navigation/native": "^7.1.10",
+        "@react-navigation/native": "^7.1.11",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0"
@@ -4509,12 +4511,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
-      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.1.tgz",
+      "integrity": "sha512-MX4Zioh39chHlDJbKmEgydJDS3tspMP/lnQC67G3SWsTnb9NeYVWOjkxpOSy4oMfPs4StcWHwBrvUb4ybfnuaw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/node-forge": {
@@ -4533,9 +4535,9 @@
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.14",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -4873,9 +4875,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4896,9 +4898,9 @@
       }
     },
     "node_modules/acorn-loose": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.0.tgz",
-      "integrity": "sha512-ppga7pybjwX2HSJv5ayHe6QG4wmNS1RQ2wjBMFTVnOj0h8Rxsmtc6fnVzINqHSSRz23sTe9IL3UAt/PU9gc4FA==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.1.tgz",
+      "integrity": "sha512-H68u/wiI8PAsSBclEIWwUg3dqEaDZXQHCovulbedgp78zJstjn7gDjfGgwUtW0BHi+KasryFLreHAGX/iXU85A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5481,9 +5483,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5699,9 +5701,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001721",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001721.tgz",
-      "integrity": "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ==",
+      "version": "1.0.30001723",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001723.tgz",
+      "integrity": "sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==",
       "funding": [
         {
           "type": "opencollective",
@@ -6137,12 +6139,12 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.42.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.42.0.tgz",
-      "integrity": "sha512-bQasjMfyDGyaeWKBIu33lHh9qlSR0MFE/Nmc6nMjf/iU9b3rSMdAYz1Baxrv4lPdGUsTqZudHA4jIGSJy0SWZQ==",
+      "version": "3.43.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.43.0.tgz",
+      "integrity": "sha512-2GML2ZsCc5LR7hZYz4AXmjQw8zuy2T//2QntwdnpuYI7jteT6GVYJL7F6C2C57R7gSYrcqVW3lAALefdbhBLDA==",
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.24.4"
+        "browserslist": "^4.25.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6663,9 +6665,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.165",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.165.tgz",
-      "integrity": "sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw==",
+      "version": "1.5.167",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.167.tgz",
+      "integrity": "sha512-LxcRvnYO5ez2bMOFpbuuVuAI5QNeY1ncVytE/KXaL6ZNfzX1yPlAO0nSOyIHx2fVAuUprMqPs/TdVhUFZy7SIQ==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -6721,9 +6723,9 @@
       }
     },
     "node_modules/entities": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
-      "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -7213,9 +7215,9 @@
       }
     },
     "node_modules/expo-image": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-2.2.0.tgz",
-      "integrity": "sha512-ushj+R0s07hBZeuYziW3ejj/vlgzNtI/uEaYS5zIQdGz6bXQHLp7l7H6NTx7dKBeHE8ESc8mE5yTgf0YZEHITw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-2.3.0.tgz",
+      "integrity": "sha512-muL8OSbgCskQJsyqenKPNULWXwRm5BY2ruS6WMo/EzFyI3iXI/0mXgb2J/NXUa8xCEYxSyoGkGZFyCBvGY1ofA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -7380,16 +7382,17 @@
       }
     },
     "node_modules/expo-router/node_modules/@react-navigation/elements": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.4.3.tgz",
-      "integrity": "sha512-psoNmnZ0DQIt9nxxPITVLtYW04PGCAfnmd/Pcd3yhiBs93aj+HYKH+SDZDpUnXMf3BN7Wvo4+jPI+/Xjqb+m9w==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.4.4.tgz",
+      "integrity": "sha512-6OAzrg6mn8s3qv6DZSFHxYRZv/3hUZTtkrq1XNBqLNlVIv89Iv7XKukYbZIxNoUss8r+RLJea0aNAOq5jbBkfw==",
       "license": "MIT",
       "dependencies": {
-        "color": "^4.2.3"
+        "color": "^4.2.3",
+        "use-latest-callback": "^0.2.4"
       },
       "peerDependencies": {
         "@react-native-masked-view/masked-view": ">= 0.2.0",
-        "@react-navigation/native": "^7.1.10",
+        "@react-navigation/native": "^7.1.11",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0"
@@ -7401,16 +7404,16 @@
       }
     },
     "node_modules/expo-router/node_modules/@react-navigation/native": {
-      "version": "7.1.10",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.10.tgz",
-      "integrity": "sha512-Ug4IML0DkAxZTMF/E7lyyLXSclkGAYElY2cxZWITwfBjtlVeda0NjsdnTWY5EGjnd7bwvhTIUC+CO6qSlrDn5A==",
+      "version": "7.1.11",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.11.tgz",
+      "integrity": "sha512-f/UETxy2Nahr8jko9mSSRBvIaDubGc3M2yx5pWxMPxZgLkB4TqPB0O1OFdbcAuRDwLgzXXK+Joh7nTdGug9v2A==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/core": "^7.10.0",
+        "@react-navigation/core": "^7.10.1",
         "escape-string-regexp": "^4.0.0",
         "fast-deep-equal": "^3.1.3",
         "nanoid": "^3.3.11",
-        "use-latest-callback": "^0.2.3"
+        "use-latest-callback": "^0.2.4"
       },
       "peerDependencies": {
         "react": ">= 18.2.0",
@@ -7418,16 +7421,16 @@
       }
     },
     "node_modules/expo-router/node_modules/@react-navigation/native-stack": {
-      "version": "7.3.14",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.3.14.tgz",
-      "integrity": "sha512-45Sf7ReqSCIySXS5nrKtLGmNlFXm5x+u32YQMwKDONCqVGOBCfo4ryKqeQq1EMJ7Py6IDyOwHMhA+jhNOxnfPw==",
+      "version": "7.3.16",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.3.16.tgz",
+      "integrity": "sha512-tK29buswgQtHE/8+HMeYfsio/t6Y0Yk+YlEBckaYvNbxOrCwQ/s2FrM4dyV3dHkSefT6eEae3NKSgD0Q2ARMAA==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/elements": "^2.4.3",
+        "@react-navigation/elements": "^2.4.4",
         "warn-once": "^0.1.1"
       },
       "peerDependencies": {
-        "@react-navigation/native": "^7.1.10",
+        "@react-navigation/native": "^7.1.11",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0",
@@ -7876,9 +7879,9 @@
       "license": "MIT"
     },
     "node_modules/flow-parser": {
-      "version": "0.273.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.273.0.tgz",
-      "integrity": "sha512-KHe9AJfT0Zn0TpQ2daDFBpwaE0zqjWWiWLOANxzo/U6Xar5fRpU3Lucnk8iMVNitxo9inz2OmSnger70qHmsLw==",
+      "version": "0.273.1",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.273.1.tgz",
+      "integrity": "sha512-UTTfeYIhxYJ7xuW+HL9oyx6lnUGx1+W5Cyo8hOPgMrDU49GANfONtkb9dguDvIyQ20fz8CHZwB25ZP2206bBWQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -8133,9 +8136,9 @@
       "peer": true
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -14415,9 +14418,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.41.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.41.0.tgz",
-      "integrity": "sha512-H406eLPXpZbAX14+B8psIuvIr8+3c+2hkuYzpMkoE0ij+NdsVATbA78vb8neA/eqrj7rywa2pIkdmWRsXW6wmw==",
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.42.0.tgz",
+      "integrity": "sha512-UYCvU9YQW2f/Vwl+P0GfhxJxbUGLwd+5QrrGgLajzWAtC/23AX0vcise32kkP7Eu0Wu9VlzzHAXkLObgjQfFlQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -14717,9 +14720,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -14858,9 +14861,9 @@
       }
     },
     "node_modules/use-latest-callback": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.2.3.tgz",
-      "integrity": "sha512-7vI3fBuyRcP91pazVboc4qu+6ZqM8izPWX9k7cRnT8hbD5svslcknsh3S9BUhaK11OmgTV4oWZZVSeQAiV53SQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.2.4.tgz",
+      "integrity": "sha512-LS2s2n1usUUnDq4oVh1ca6JFX9uSqUncTfAm44WMg0v6TxL7POUTk1B044NH8TeLkFbNajIsgDHcgNpNzZucdg==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@react-native-community/datetimepicker": "8.2.0",
     "@react-native-picker/picker": "2.9.0",
     "@react-navigation/bottom-tabs": "7.2.0",
-    "@react-navigation/native": "^7.0.15",
+    "@react-navigation/native": "7.1.x",
     "@react-navigation/stack": "7.1.2",
     "@supabase/supabase-js": "^2.49.8",
     "expo": "^52.0.46",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
   "dependencies": {
     "@expo/cli": "^0.22.26",
     "@expo/vector-icons": "^14.0.4",
-    "@react-native-async-storage/async-storage": "^1.23.1",
+    "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-community/datetimepicker": "8.2.0",
     "@react-native-picker/picker": "2.9.0",
     "@react-navigation/bottom-tabs": "7.2.0",
-    "@react-navigation/native": "7.0.15",
+    "@react-navigation/native": "^7.0.15",
     "@react-navigation/stack": "7.1.2",
     "@supabase/supabase-js": "^2.49.8",
     "expo": "^52.0.46",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@expo/cli": "^0.22.26",
     "@expo/vector-icons": "^14.0.4",
-    "@react-native-async-storage/async-storage": "1.23.1",
+    "@react-native-async-storage/async-storage": "^1.23.1",
     "@react-native-community/datetimepicker": "8.2.0",
     "@react-native-picker/picker": "2.9.0",
     "@react-navigation/bottom-tabs": "7.2.0",


### PR DESCRIPTION
## Summary & Changes 📃
- **Resolves:** breaking change of issue #168  

Noticed the issue occurring here in this commit [4f63c1b](https://github.com/SeattleColleges/shift-app-expo/commit/4f63c1bca70d1e93eb207c1f2a16182044ab2a9d) was that the specific version of natives was stopping the main app features page from loading. You can see the screen shot in my comment on the commit. 

To fix this change we have to allow for patch updates of the @react-navigation/natives dependency. Not sure exactly which version of the dependency is needed but that doesn't matter if we leave the caret. 

## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: Install the app
   - Step 2: Run the app in mobile environment
   - Step 3: Click the first link on the home page to make sure that the (tabs)/_layout.tsx page is still loading. 


